### PR TITLE
Minor fix to sed command on OSX

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -215,12 +215,12 @@ update_credentials() {
     # sed -i means 'replace in-place'
     if grep -q '%NAME_FIRST_LAST%' "$ROOT/.gitconfig" "$ROOT/.hgrc"; then
         read -p "Enter your full name (First Last): " name
-        sed -i'' -e "s/%NAME_FIRST_LAST%/$name/g" "$ROOT/.gitconfig" "$ROOT/.hgrc"
+        perl -pli -e "s/%NAME_FIRST_LAST%/$name/g" "$ROOT/.gitconfig" "$ROOT/.hgrc"
     fi
 
     if grep -q '%EMAIL%' "$ROOT/.gitconfig" "$ROOT/.hgrc"; then
         read -p "Enter your KA email, without the @khanacademy.org (e.g. $USER): " email
-        sed -i'' -e "s/%EMAIL%/$email/g" "$ROOT/.gitconfig" "$ROOT/.hgrc"
+        perl -pli -e "s/%EMAIL%/$email/g" "$ROOT/.gitconfig" "$ROOT/.hgrc"
     fi
 }
 


### PR DESCRIPTION
OSX's sed flavor is slightly different from the standard unix. Usually,
if you omit a backup extension during in-place operations no backup
files will be created. On OSX you must instead specify an empty string.

More details at http://stackoverflow.com/questions/4247068/
