### PR TITLE
Change default editor for git on MacOS

### DIFF
--- a/.bashrc.khan
+++ b/.bashrc.khan
@@ -22,6 +22,9 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 source "$DIR/git-completion.bash"
 source "$DIR/hg-completion.bash"
 
+# Make sure git (and other apps) prefer 'vim' to 'vi'.
+: ${EDITOR:=vim}
+
 # Set a high limit for open file descriptors per shell.
 # The default on OS X is 256; we increase it to 1024--the default value of
 # `sysctl kern.maxfilesperproc`, which `ulimit -n` must not exceed.


### PR DESCRIPTION
I and others have had the problem where git would lose a commit message for no apparant reason, forcing people to have to write it again. This is annoying. According to the internets, setting the editor to vim instead of the default vi fixes this problem. Who uses vi anyway?

See http://apple.stackexchange.com/questions/57672/error-there-was-a-problem-with-the-editor-vi-when-using-it-with-git

Test Plan:
Make sure setup.sh still works (cross fingers)
