### PR TITLE
Update dotfiles to support zsh

### DIFF
--- a/.profile.khan
+++ b/.profile.khan
@@ -47,3 +47,26 @@ if [ `uname -s` = Darwin ]; then
     # We use the timeout command a lot, but os x calls it `gtimeout`.
     alias timeout=gtimeout
 fi
+
+# Activate Python2.7 virtualenv if present
+if [ -s ~/.virtualenv/khan27/bin/activate ]; then
+  source ~/.virtualenv/khan27/bin/activate
+else
+  echo "[WARN]  Could not find '~/.virtualenv/khan27/bin/activate'"\
+    "- All processes that depend on Python may be negatively impacted."\
+    "Please run 'make' from the dotfiles directory to fix this."
+fi
+
+# Since we auto-activate the khan27 virtualenv, we don't want pipenv using any
+# virtualenv it happens to find itself in, but instead to use its own.
+# TODO(benkraft): If in the future we move to pipenv everywhere, we can
+# dispense with the auto-activated virtualenvs, and get rid of this.
+export PIPENV_IGNORE_VIRTUALENVS=1
+
+# Make sure git (and other apps) prefer 'vim' to 'vi'.
+: ${EDITOR:=vim}
+
+# Set a high limit for open file descriptors per shell.
+# The default on OS X is 256; we increase it to 1024--the default value of
+# `sysctl kern.maxfilesperproc`, which `ulimit -n` must not exceed.
+ulimit -S -n 1024

--- a/.zprofile.khan
+++ b/.zprofile.khan
@@ -1,13 +1,12 @@
 ################################################################################
-# Khan Academy specific .bash_profile
+# Khan Academy specific .zprofile
 #
-# The difference between .bash_profile and .profile is that the latter
-# is called for all sh-compatible shells.  So we put bashisms here
-# and non-bashisms in .profile.
+# The difference between .zprofile and .profile is that the latter
+# is called for all sh-compatible shells.  So we put zshisms here
+# and non-zshisms in .profile.
 #
-# According to the bash manpage, if both .bash_profile and .profile
-# exist, bash only reads the first one.  So we have to source .profile
-# manually.
+# The zsh shell does not load .profile itself, so we have to source
+# .profile here.
 
 if [ -z "$KA_DOTFILES_PROFILE_SOURCED" ]; then
    # We check and then set this environment variable to ensure that we source
@@ -22,8 +21,8 @@ unset KA_DOTFILES_PROFILE_SOURCED
 
 # Figure out what directory we're *really* in (following symlinks).
 # We need this because *-completion.bash are siblings to this script.
-# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
-SOURCE="${BASH_SOURCE[0]}"
+# https://stackoverflow.com/questions/9901210/bash-source0-equivalent-in-zsh
+SOURCE="${(%):-%N}"
 while [ -h "$SOURCE" ]; do   # follow symlinks
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
   SOURCE="$(readlink "$SOURCE")"
@@ -31,8 +30,10 @@ while [ -h "$SOURCE" ]; do   # follow symlinks
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-# Enable autocompletion for git
+# Enable autocompletion for git. Should use git-completion.zsh, but it seems problematic on mac
+autoload -Uz compinit && compinit
 source "$DIR/git-completion.bash"
+
 # Similarly for gcloud, if available
 if ! which gcloud >/dev/null; then
     GCLOUD_COMPLETION_FILE="$(basename "$(basename gcloud)")/completion.bash.inc"

--- a/mac-setup.sh
+++ b/mac-setup.sh
@@ -541,9 +541,9 @@ notice "interact with, or a script will run for you to use\n"
 notice "Press enter when a download/install is completed to go to"
 notice "the next step (including this one)"
 
-if ! echo "$SHELL" | grep -q '/bash$' ; then
+if ! echo "$SHELL" | grep -q -e '/bash$' -e '/zsh$' ; then
     echo
-    warn "It looks like you're using a shell other than bash!"
+    warn "It looks like you're using a shell other than bash or zsh!"
     notice "Other shells are not officially supported.  Most things"
     notice "should work, but dev-support help is not guaranteed."
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -111,8 +111,8 @@ install_dotfiles() {
     # TODO(benkraft): Add more specific instructions for other common shells,
     # or just write dotfiles for them.
     shell="`basename "$SHELL"`"
-    if [ "$shell" != bash ] && [ -z "$VIRTUAL_ENV" ] ; then
-        add_fatal_error "Your default shell is $shell, not bash, so you'll" \
+    if [ -z "$VIRTUAL_ENV" ] && [ "$shell" != bash ] && [ "$shell" != zsh ]; then
+        add_fatal_error "Your default shell is $shell, not bash or zsh, so you'll" \
                         "need to update its config manually to activate our" \
                         "virtualenv. You can follow the instructions at" \
                         "khanacademy.org/r/virtualenvs to create a new" \

--- a/zprofile.default
+++ b/zprofile.default
@@ -1,0 +1,7 @@
+################################################################################
+# Local .zprofile.
+# Feel free to add whatever you like after the profile.khan' line.
+
+if [ -s ~/.zprofile.khan ]; then
+    . ~/.zprofile.khan
+fi


### PR DESCRIPTION
Summary:
Make necessary fixes to allow engineers to use zsh as their default shell on MacOS

Issue: https://khanacademy.atlassian.net/browse/INFRA-4149

Test Plan:
Run make install on clean mac install using zsh (via vm)
Run make install on pre-run mac install after switching to zsh
(not tested) zsh on linux

Reviewers: Kai, csilvers, benkraft

Reviewed By: Kai, csilvers, benkraft

Subscribers: csilvers

Differential Revision: https://phabricator.khanacademy.org/D60920