### PR TITLE
Update dotfiles for node@10 and other improvements

### DIFF
--- a/.profile.khan
+++ b/.profile.khan
@@ -43,6 +43,7 @@ if [ `uname -s` = Darwin ]; then
     # Link openssl into build flags
     export LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS"
     export CPPFLAGS="-I/usr/local/opt/openssl/include $CPPFLAGS"
+    export CFLAGS="-I/usr/local/include -L/usr/local/lib $CFLAGS"
 
     # We use the timeout command a lot, but os x calls it `gtimeout`.
     alias timeout=gtimeout

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -70,20 +70,19 @@ install_packages() {
         updated_apt_repo=yes
     fi
     if ! ls /etc/apt/sources.list.d/ 2>&1 | grep -q nodesource || \
-       ! grep -q node_8.x /etc/apt/sources.list.d/nodesource.list; then
-        # This is a simplified version of https://deb.nodesource.com/setup_8.x
+       ! grep -q node_10.x /etc/apt/sources.list.d/nodesource.list; then
+        # This is a simplified version of https://deb.nodesource.com/setup_10.x
         wget -O- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
         cat <<EOF | sudo tee /etc/apt/sources.list.d/nodesource.list
-deb https://deb.nodesource.com/node_8.x `lsb_release -c -s` main
-deb-src https://deb.nodesource.com/node_8.x `lsb_release -c -s` main
+deb https://deb.nodesource.com/node_10.x `lsb_release -c -s` main
+deb-src https://deb.nodesource.com/node_10.x `lsb_release -c -s` main
 EOF
         sudo chmod a+rX /etc/apt/sources.list.d/nodesource.list
 
-        # Pin nodejs to 8.x, otherwise apt will update it to 10.x on newer
-        # Ubuntu versions
+        # Pin nodejs to 10.x, otherwise apt will update newer Ubuntu versions
         cat <<EOF | sudo tee /etc/apt/preferences.d/nodejs
 Package: nodejs
-Pin: version 8.*
+Pin: version 10.*
 Pin-Priority: 999
 EOF
         updated_apt_repo=yes
@@ -118,7 +117,7 @@ EOF
     # libncurses-dev and libreadline-dev are needed for readline
     # nginx is used as a devserver proxy that serves static files
     # nodejs is used for various frontendy stuff in webapp, and
-    #   we standardize on version 8.
+    #   we standardize on version 10.
     # redis is needed to run memorystore on dev
     # TODO(benkraft): Pull the version we want from webapp somehow.
     # curl for various scripts (including setup.sh)
@@ -130,7 +129,7 @@ EOF
         libxslt1-dev \
         libyaml-dev \
         libncurses-dev libreadline-dev \
-        nodejs=8* \
+        nodejs=10* \
         nginx \
         redis-server \
         curl

--- a/mac-setup.sh
+++ b/mac-setup.sh
@@ -280,20 +280,18 @@ update_git() {
 
 install_node() {
     if ! which node >/dev/null 2>&1; then
-        # to break the dependence between node@8 and icu4c@63.x
-        # to uninstall icu4c@63.x before re-install node@8
-        # so node@8 will work with icu4c@64.x which installed from postgres@11
-        # https://khanacademy.slack.com/archives/C8Y4Q1E0J/p1560792688074600
-        if brew ls icu4c --versions | grep "icu4c 63"; then
-            brew uninstall --ignore-dependencies icu4c@63.1
-        fi
-        # Install node 8: webapp doesn't (yet!) work with node 10.
-        # (Node 8 is LTS.)
-        brew install node@8
+        # Install node 10: webapp doesn't (yet!) work with node 12.
+        # (Node 10 is LTS.)
+        brew install node@10
 
         # We need this because brew doesn't link /usr/local/bin/node
         # by default when installing non-latest node.
-        brew link --force --overwrite node@8
+        brew link --force --overwrite node@10
+    fi
+    if ! which yarn >/dev/null 2>&1; then
+        # Using brew to install node 10 seems to prevent npm from
+        # correctly installing yarn. Use brew instead
+        brew install yarn
     fi
 }
 
@@ -468,6 +466,13 @@ install_python_tools() {
     if ! brew ls pyenv >/dev/null 2>&1; then
         info "Installing pyenv\n"
         brew install pyenv
+        # At the moment, we depend on MacOS coming with python 2.7. If that
+        # stops, or we want to align the python versions with the linux
+        # dotfiles more effectively, we could do it with pyenv:
+        # `pyenv install 2.7.16 ; pyenv global 2.7.16`
+        # Because the linux dotfiles do not yet install pyenv, holding off on
+        # using pyenv to enforce python version until either that happens, or
+        # MacOs stops including python 2.7 by default.
     else
         success "pyenv already installed"
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -244,7 +244,7 @@ install_deps() {
 
     # Install virtualenv.
     # https://docs.google.com/document/d/1zrmm6byPImfbt7wDyS8PpULwnEckSxna2jhSl38cWt8
-    sudo pip install -q virtualenv
+    sudo pip install -q virtualenv==v16.7.9
 
     create_and_activate_virtualenv "$ROOT/.virtualenv/khan27"
 


### PR DESCRIPTION
Summary:
Update dotfiles to install node@10, as brew removed formula for node@8

Test Plan:
Run make install on clean mac install (via vm)
Run make install on clean ubuntu install (via vm)
Run make install on pre-run mac install