### PR TITLE
Quick fix to remove a bashism from .profile.khan

### DIFF
--- a/.profile.khan
+++ b/.profile.khan
@@ -50,7 +50,7 @@ fi
 
 # Activate Python2.7 virtualenv if present
 if [ -s ~/.virtualenv/khan27/bin/activate ]; then
-  source ~/.virtualenv/khan27/bin/activate
+  . ~/.virtualenv/khan27/bin/activate
 else
   echo "[WARN]  Could not find '~/.virtualenv/khan27/bin/activate'"\
     "- All processes that depend on Python may be negatively impacted."\


### PR DESCRIPTION
Summary:
The 'source' command is not valid on dash, the default 'sh' shell on ubuntu. As such, it can't be used in .profile.khan

Issue: none

Test Plan: Test on Ubuntu that .profile.khan loads correctly

Reviewers: csilvers, Kai

Reviewed By: csilvers

Subscribers: csilvers

Differential Revision: https://phabricator.khanacademy.org/D61031