### PR TITLE
DEV-450: Add an output to indicate how far behind master the users current webapp branch is

### DIFF
--- a/bin/system_report.sh
+++ b/bin/system_report.sh
@@ -180,6 +180,7 @@ header "Webapp"
 kv "WEBAPP_ROOT" "$WEBAPP_ROOT"
 if [ -d "$WEBAPP_ROOT" ]; then
     kv_multiline "make check_setup" "$( (cd "$WEBAPP_ROOT" && make check_setup) )"
+    kv "Current Branch Trails Master by" "$(git --git-dir $WEBAPP_ROOT/.git rev-list --left-only --count origin/master...HEAD) commits"
 else
     kv "!!! WARNING !!!" "$WEBAPP_ROOT could not be found!"
 fi

--- a/bin/system_report.sh
+++ b/bin/system_report.sh
@@ -180,7 +180,8 @@ header "Webapp"
 kv "WEBAPP_ROOT" "$WEBAPP_ROOT"
 if [ -d "$WEBAPP_ROOT" ]; then
     kv_multiline "make check_setup" "$( (cd "$WEBAPP_ROOT" && make check_setup) )"
-    kv "Current Branch Trails Master by" "$(git --git-dir $WEBAPP_ROOT/.git rev-list --left-only --count origin/master...HEAD) commits"
+    kv "Current Branch Trails Master by" "$(git --git-dir "$WEBAPP_ROOT"/.git rev-list --left-only --count origin/master...HEAD) commits"
+    kv "Diverged from master at" "$(git --git-dir "$WEBAPP_ROOT"/.git HEAD origin/master| git --git-dir "$WEBAPP_ROOT"/.git show --pretty='%h %cs' -q)"
 else
     kv "!!! WARNING !!!" "$WEBAPP_ROOT could not be found!"
 fi


### PR DESCRIPTION
## Summary:
Caveat: if the user has not `git fetch`'ed in a while, the number may be wrong, however the merge base should still be correct. This only checks whichever branch the user is _currently_ on.


Issue: DEV-450

## Test plan:
1. Run `system_report.sh`
2. Check report for the Webapp section, should see something like:
```
	Webapp:
WEBAPP_ROOT:         /Users/davidbraley/khan/webapp
make check_setup:
make[1]: Nothing to be done for `decrypt_secrets'.
gcloud/verify_gcloud_setup.py

Current Branch Trails Master by: 11 commits
Diverged from master at: 8757b10afdc 2021-04-04
```