### PR TITLE
INFRA-6493: Fix mac-setup.sh homebrew setup

### DIFF
--- a/.profile.khan
+++ b/.profile.khan
@@ -5,6 +5,11 @@
 # is called for all sh-compatible shells.  So we put non-bashisms here
 # and bashisms in .bash_profile.
 
+# Add homebrew to path on M1 macs
+if [[ $(uname -m) = "arm64" ]]; then
+    export PATH=/opt/homebrew/bin:$PATH
+fi
+
 # Add frankenserver bins to PATH
 export PATH="$HOME/khan/webapp/third_party/frankenserver:$PATH"
 

--- a/bin/edit-system-config.sh
+++ b/bin/edit-system-config.sh
@@ -11,20 +11,22 @@ set -e
 ROOT=${1-$HOME}
 mkdir -p "$ROOT"
 
+MIMETYPES="$(brew --prefix)/etc/mime.types"
+
 echo "Modifying system configs"
 
 # This command avoids the spew when you deploy the Khan Academy
 # appengine app:
 #   Cannot guess mime-type for XXX.  Using application/octet-stream
 line="application/octet-stream  less eot ttf woff otf as fla sjs flash tmpl"
-if [ -s /usr/local/etc/mime.types ]; then
+if [ -s $MIMETYPES ]; then
     # Replace any existing line with 'less' and 'eot' with the new line.
-    grep -v 'less eot' /usr/local/etc/mime.types | \
-        sudo sh -c "cat; echo '$line' > /usr/local/etc/mime.types"
+    grep -v 'less eot' $MIMETYPES | \
+        sudo sh -c "cat; echo '$line' > $MIMETYPES"
 else
-    sudo sh -c 'echo "$line" > /usr/local/etc/mime.types'
+    sudo sh -c 'echo "$line" > '"$MIMETYPES"
 fi
-sudo chmod a+r /usr/local/etc/mime.types
+sudo chmod a+r $MIMETYPES
 
 # If there is no ssh key, make one.
 mkdir -p "$ROOT/.ssh"

--- a/mac-setup-elevated.sh
+++ b/mac-setup-elevated.sh
@@ -77,6 +77,15 @@ install_protoc() {
 echo "This setup script needs your password to install things as root."
 sudo sh -c 'echo Thanks'
 
+if [[ $(uname -m) = "arm64" ]]; then
+    # install rosetta on M1 (required for openjdk, python2 and other things)
+    # This will work here, but it requires input and I'd rather just have it in docs
+    #sudo softwareupdate --install-rosetta
+
+    # Add homebrew to path on M1 macs
+    export PATH=/opt/homebrew/bin:$PATH
+fi
+
 # Add github to known_hosts (one less prompt when QAing script)
 mkdir -p ~/.ssh
 grep -q github.com ~/.ssh/known_hosts 2>/dev/null || \

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -6,6 +6,11 @@
 # Bail on any errors
 set -e
 
+if [[ $(uname -m) = "arm64" ]]; then
+    # Add homebrew to path on M1 macs
+    export PATH=/opt/homebrew/bin:$PATH
+fi
+
 tty_bold=`tput bold`
 tty_normal=`tput sgr0`
 
@@ -306,7 +311,7 @@ install_openssl() {
         success "openssl already installed"
     fi
     for source in $(brew --prefix openssl)/lib/*.dylib ; do
-        dest="/usr/local/lib/$(basename $source)"
+        dest="$(brew --prefix)/lib/$(basename $source)"
         # if dest is already a symlink pointing to the correct source, skip it
         if [ -h "$dest" -a "$(readlink "$dest")" = "$source" ]; then
             :


### PR DESCRIPTION
Intel macs put homebrew into /usr/local/bin. These are intel only
binaries. M1 macs put homebrew into /opt/homebrew. This now needs
to be in our path.

See https://www.reddit.com/r/MacOS/comments/jw9guu/why_did_homebrew_move_from_usrlocalto_opthomebrew/

Issue: https://khanacademy.atlassian.net/browse/INFRA-6493

Test Plan:

Run mac-setup.sh on M1 mac and on an intel mac and verify it works.