### PR TITLE
INFRA-6554 khan-dotfiles setup.sh M1 fixes

### DIFF
--- a/.profile.khan
+++ b/.profile.khan
@@ -40,7 +40,11 @@ export PATH="$HOME/.local/bin:$PATH"
 # if they have brew and have our python@2 formula installed
 # See: https://github.com/Khan/homebrew-repo/blob/master/Formula/python%402.rb
 if brew --prefix khan/repo/python@2 >/dev/null 2>&1; then
-    export PATH="$(brew --prefix khan/repo/python@2)/libexec/bin:$PATH"
+    # This will exist if native python2 is installed (usually only on intel)
+    PY2_BIN="$(brew --prefix khan/repo/python@2)"
+    # On a M1 machine, we run python2 via rosetta out of /usr/local
+    [ -d "$PY2_BIN" ] || PY2_BIN="/usr/local/opt/python@2"
+    export PATH="$PY2_BIN/libexec/bin:$PATH"
 fi
 
 # Make sure git (and other apps) prefer 'vim' to 'vi'.

--- a/setup-gcloud.sh
+++ b/setup-gcloud.sh
@@ -59,8 +59,13 @@ if ! which gcloud >/dev/null; then
     # On mac, we could alternately do `brew install google-cloud-sdk`,
     # but we need this code for linux anyway, so we might as well be
     # consistent across platforms; this also makes dotfiles simpler.
-    platform="$(uname -s | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz)-$(uname -m)"
+    # Also (2021), brew does not supply the version we want on M1.
+    arch="$(uname -m)"
+    # Use rosetta for gcloud on M1
+    [ `uname -m` = "arm64" ] && arch="x86_64"
+    platform="$(uname -s | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz)-$arch"
     gcloud_url="https://storage.googleapis.com/cloud-sdk-release/google-cloud-sdk-$version-$platform.tar.gz"
+    echo "$SCRIPT: Installing from $gcloud_url"
     local_archive_filename="/tmp/gcloud-$version.tar.gz"
     curl "$gcloud_url" >"$local_archive_filename"
     (

--- a/setup.sh
+++ b/setup.sh
@@ -318,11 +318,12 @@ setup_arc() {
 }
 
 
+install_dotfiles
+
 check_dependencies
 
-# the order of these individually doesn't matter but they should come first
 update_userinfo
-install_dotfiles
+
 # the order for these is (mostly!) important, beware
 clone_repos
 install_and_setup_gcloud


### PR DESCRIPTION
* Install shell dotfiles before anything else
* Fix gcloud download issue & run under rosetta
* Fix PATH to python2

See also https://khanacademy.atlassian.net/wiki/spaces/INFRA/pages/1586299061/DevEnv+Setting+up+khan-dotfiles+on+a+M1+mac

Issue: https://khanacademy.atlassian.net/browse/INFRA-6554

Test plan:
* Just run 'make' from khan-dotfiles. It should run on a clean
  M1, intel and ubuntu 20 machines. It should also run on
  machines that are not clean