### PR TITLE
INFRA-6588 Move node,rust to rosetta

### DIFF
--- a/bin/install-mac-rust.py
+++ b/bin/install-mac-rust.py
@@ -7,6 +7,10 @@
 
 import subprocess
 
-subprocess.run(['brew', 'install', 'rustup-init'], check=True)
+# M1 requires we run under rosetta, thus /usr/local/bin/brew
+# The same command works for both intel & M1 macs
+subprocess.run(
+    ['arch', '-x86_64', '/usr/local/bin/brew', 'install', 'rustup-init'],
+    check=True)
 subprocess.run(['rustup-init', '-y', '-t', 'wasm32-wasi', '--no-modify-path'],
                check=True)

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -202,20 +202,23 @@ install_python2() {
 }
 
 install_node() {
+    BREW=brew
+    [ `uname -m` = "arm64" ] && BREW="arch -x86_64 /usr/local/bin/brew"
+
     if ! which node >/dev/null 2>&1; then
         # Install node 12: It's LTS and the latest version supported on
         # appengine standard.
-        brew install node@12
+        $BREW install node@12
 
         # We need this because brew doesn't link /usr/local/bin/node
         # by default when installing non-latest node.
-        brew link --force --overwrite node@12
+        $BREW link --force --overwrite node@12
     fi
     # We don't want to force usage of node v12, but we want to make clear we
     # don't support anything else.
     if ! node --version | grep "v12" >/dev/null ; then
         notice "Your version of node is $(node --version). We currently only support v12."
-        if brew ls --versions node@12 >/dev/null ; then
+        if $BREW ls --versions node@12 >/dev/null ; then
             notice "You do however have node 12 installed."
             notice "Consider running:"
         else


### PR DESCRIPTION
See https://khanacademy.atlassian.net/wiki/spaces/INFRA/pages/1586299061/DevEnv+Setting+up+khan-dotfiles+on+a+M1+mac

node@12 must be run under rosetta
While there is node@12 for M1, it is broken. (Reliable node does not work on
M1 until v15 or v16 from the interwebs.) Thus, node must be installed &
linked via x86 brew.

arch -x86_64 /usr/local/bin/brew install node@12
arch -x86_64 /usr/local/bin/brew link --force --overwrite node@12

rust must be run under rosetta
While there is a M1 version, it doesn’t work.

arch -x86_64 /usr/local/bin/brew install rustup-init
rustup-init -y -t wasm32-wasi --no-modify-path

Issue: https://khanacademy.atlassian.net/browse/INFRA-6588

Test plan:
* Uninstall node & rust
* Run khan-dotfiles
* Start webapp and ensure it comes up