### PR TITLE
Fix merge-base of system_report.sh

### DIFF
--- a/bin/system_report.sh
+++ b/bin/system_report.sh
@@ -181,7 +181,7 @@ kv "WEBAPP_ROOT" "$WEBAPP_ROOT"
 if [ -d "$WEBAPP_ROOT" ]; then
     kv_multiline "make check_setup" "$( (cd "$WEBAPP_ROOT" && make check_setup) )"
     kv "Current Branch Trails Master by" "$(git --git-dir "$WEBAPP_ROOT"/.git rev-list --left-only --count origin/master...HEAD) commits"
-    kv "Diverged from master at" "$(git --git-dir "$WEBAPP_ROOT"/.git HEAD origin/master| git --git-dir "$WEBAPP_ROOT"/.git show --pretty='%h %cs' -q)"
+    kv "Diverged from master at" "$(git --git-dir "$WEBAPP_ROOT"/.git show --pretty='https://github.com/Khan/webapp/commit/%h %cs' -q "$(git --git-dir "$WEBAPP_ROOT"/.git merge-base HEAD origin/master)")"
 else
     kv "!!! WARNING !!!" "$WEBAPP_ROOT could not be found!"
 fi


### PR DESCRIPTION
There were two errors in the git command, one of which spat out an error the shell, and the other made the output unreliable.
This fixes that, and improves it by providing the url of the diff rather than just the hash

Issue: "none"

Test plan:
Created a branch off of and old copy of webapp master, added a few commits, then ran the script. Saw no errors, and further observed that the provided info `Diverged from master at: https://github.com/Khan/webapp/commit/c7c898e594f 2021-06-30` was the LAST commit on master that was also on my branch (ie the common base).