### PR TITLE
INFRA-6590: Do not install docker by default

### DIFF
--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -390,6 +390,4 @@ install_helpful_tools
 install_watchman
 install_python_tools
 
-"$DEVTOOLS_DIR"/khan-dotfiles/bin/install-mac-k8s.py
-
 trap - EXIT


### PR DESCRIPTION
With the parallels-VM testing infrastucture DevOps occasionally
uses to validate khan-dotfiles, running this automatically causes
khan-dotfiles to fail to install properly.

Issue: https://khanacademy.atlassian.net/browse/INFRA-6590

Test plan:

Run 'make' to install khan-dotfiles. They succeed both
locally and in a parallels VM.