### PR TITLE
INFRA-6741 Fix mime.types assumption

### DIFF
--- a/bin/edit-system-config.sh
+++ b/bin/edit-system-config.sh
@@ -15,10 +15,6 @@ echo "Modifying system configs"
 
 MIMETYPES="/etc/mime.types"
 [ `uname -s` = Darwin ] && MIMETYPES="$(brew --prefix)/etc/mime.types"
-if [ ! -f "$MIMETYPES" ]; then
-    echo "Could not find mime.types file"
-    exit 1
-fi
 
 # This command avoids the spew when you deploy the Khan Academy
 # appengine app:


### PR DESCRIPTION
Do not check for file existance and then exit
if it does not exist. This test was added recently.
It is a very difficult thing to test for on
several platforms in different states.

Issue: https://khanacademy.atlassian.net/browse/INFRA-6741

Test plan:

It should run on a clean mac again