### PR TITLE
Add --force-with-lease and --no-edit to completion file

### DIFF
--- a/git-completion.bash
+++ b/git-completion.bash
@@ -1276,7 +1276,7 @@ _git_commit ()
 	--*)
 		__gitcomp "
 			--all --author= --signoff --verify --no-verify
-			--edit --amend --include --only --interactive
+			--edit --no-edit --amend --include --only --interactive
 			--dry-run --reuse-message= --reedit-message=
 			--reset-author --file= --message= --template=
 			--cleanup= --untracked-files --untracked-files=
@@ -1735,7 +1735,7 @@ _git_push ()
 	--*)
 		__gitcomp "
 			--all --mirror --tags --dry-run --force --verbose
-			--receive-pack= --repo=
+			--force-with-lease --receive-pack= --repo=
 		"
 		return
 		;;


### PR DESCRIPTION
```
git push --force-with-lease [...]
```
and
```
git commit --amend --no-edit [...]
```
did not auto-complete, now they should

One minor note is that now git commit --n`<tab>` will force you to
disambiguate between --no-edit and --no-verify hopefully users will be
able to live with that.

Issue: "keystrokes"

Test plan:
Test auto-complete in a terminal
