### PR TITLE
Udate the version of gcloud to install.

### DIFF
--- a/setup-gcloud.sh
+++ b/setup-gcloud.sh
@@ -53,7 +53,7 @@ PATH="$DEVTOOLS_DIR/google-cloud-sdk/bin:$PATH"
 
 echo "$SCRIPT: Using DEVTOOLS_DIR=${DEVTOOLS_DIR}"
 
-version=257.0.0  # should match webapp's MAX_SUPPORTED_VERSION
+version=360.0.0  # should match webapp's MAX_SUPPORTED_VERSION
 if ! which gcloud >/dev/null; then
     echo "$SCRIPT: Installing Google Cloud SDK (gcloud)"
     # On mac, we could alternately do `brew install google-cloud-sdk`,


### PR DESCRIPTION
## Summary:
In https://github.com/Khan/webapp/pull/1795 I updated the max
allowable version of gcloud. After than change is deployed we should
land this change to update the version of gcloud that we install.

Issue: https://khanacademy.atlassian.net/browse/INFRA-7044

## Test plan:
- run `make` and see that it doesn't fail and installs the
  correct version of gcloud.