### PR TITLE
Fix an error in install_react_native_dependencies

### DIFF
--- a/mobile-functions.sh
+++ b/mobile-functions.sh
@@ -27,5 +27,5 @@ clone_mobile_repo() {
 
 install_react_native_dependencies() {
     update "Installing react-native dependencies..."
-    (cd "$REPOS_DIR/mobile/react-native"; yarn)
+    (cd "$REPOS_DIR/mobile"; yarn)
 }


### PR DESCRIPTION
## Summary:
@lillialexis was helping me with my ios app setup and we discoverd this.
`node_modules` was getting installed in the wrong spot.

Issue: none

## Test plan:
`./mac-ios-setup.sh` runs to completion