### PR TITLE
macOS iOS Setup: install the xcodes utility

### DIFF
--- a/mac-ios-setup.sh
+++ b/mac-ios-setup.sh
@@ -21,6 +21,28 @@ KACLONE_BIN="$DEVTOOLS_DIR/ka-clone/bin/ka-clone"
 . "$REPOS_DIR/devtools/khan-dotfiles/shared-functions.sh"
 . "$REPOS_DIR/devtools/khan-dotfiles/mobile-functions.sh"
 
+# Xcodes is a tool to manage which version of Xcode is installed
+install_xcodes() {
+    if ! which xcodes; then
+        XCODES_WORKING_DIR=$(mktemp -d)
+        # Make sure we cleanup on exit
+        trap 'rm -rf -- "$XCODES_WORKING_DIR"' EXIT
+
+        # We _don't_ use Homebrew here. The Homebrew install of `xcodes`
+        # requires a functioning Xcode install, which we most likely don't if
+        # this is a clean OS install. So we just download the latest binary
+        # release from Github.
+        curl -sL https://api.github.com/repos/RobotsAndPencils/xcodes/releases/latest | \
+            jq -r '.assets[].browser_download_url' | \
+            grep xcodes.zip | \
+            wget -nv -O "$XCODES_WORKING_DIR/xcodes.zip" -i -
+
+        unzip "$XCODES_WORKING_DIR/xcodes.zip" -d "$XCODES_WORKING_DIR/"
+        sudo install -C -v "$XCODES_WORKING_DIR/xcodes" /usr/local/bin/
+        popd
+    fi
+}
+
 # Ensure Carthage is installed. Carthage is used to manage some dependencies and
 # is required to compile the app.
 install_carthage() {
@@ -45,6 +67,7 @@ install_fastlane() {
 ensure_mac_os # Function defined in shared-functions.sh.
 # TODO(hannah): Ensure setup.sh has already been run.
 clone_mobile_repo
+install_xcodes
 install_carthage
 install_fastlane
 install_homebrew_libraries

--- a/mac-ios-setup.sh
+++ b/mac-ios-setup.sh
@@ -24,6 +24,8 @@ KACLONE_BIN="$DEVTOOLS_DIR/ka-clone/bin/ka-clone"
 # Xcodes is a tool to manage which version of Xcode is installed
 install_xcodes() {
     if ! which xcodes; then
+        update "Installing xcodes utility..."
+
         XCODES_WORKING_DIR=$(mktemp -d)
         # Make sure we cleanup on exit
         trap 'rm -rf -- "$XCODES_WORKING_DIR"' EXIT
@@ -39,7 +41,6 @@ install_xcodes() {
 
         unzip "$XCODES_WORKING_DIR/xcodes.zip" -d "$XCODES_WORKING_DIR/"
         sudo install -C -v "$XCODES_WORKING_DIR/xcodes" /usr/local/bin/
-        popd
     fi
 }
 


### PR DESCRIPTION
## Summary:

We've switched to recommending the `xcodes` utility to manage Xcode
installations. This tool allows us to install a specific version of Xcode
and not have it auto upgraded (which the App Store version does). 

It has the added benefit of not having any dependencies and no runtime 
requirements (ie. it doesn't depend on a scripting engine such as ruby or node)
and so is a single-executable install. This simplifies installation and
upgrades tremendously.

Issue: "none"

## Test plan:

Run `mac-ios-setup.sh`.
Once completed, you should be able to run `xcodes list` and see all of the 
available versions of Xcode.