### PR TITLE
Force using of `python -m pip` instead of pip if local pip is broken

### DIFF
--- a/bin/pip
+++ b/bin/pip
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python2 -m pip $@

--- a/bin/pip
+++ b/bin/pip
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python2 -m pip $@
+python -m pip $@

--- a/bin/pip2
+++ b/bin/pip2
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python -m pip $@

--- a/bin/pip2
+++ b/bin/pip2
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python -m pip $@
+python2 -m pip $@

--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -164,6 +164,14 @@ create_and_activate_virtualenv() {
     # Activate the virtualenv.
     . "$1/bin/activate"
 
+    # pip may get broken by virtualenv for some reason. We're better off 
+    # calling `python -m pip` so we'll just swap in a script that does 
+    # that for us.
+    if ! pip --version 2>/dev/null ; then
+        cp bin/pip `which pip`
+        cp bin/pip2 `which pip2`
+    fi
+
     # pip20+ stopped supporting python2.7, so we need to make sure
     # we are using an older pip.
     if ! pip --version | grep -q "pip 1[0-9]"; then


### PR DESCRIPTION
During the setup of an M1, the virtualenv that gets created is routinely broken, specifically the pip binaries. There doesn't seem to be a good way to fix this, but in general it is recommended that we call `python -m pip` instead of pip directly. That seems to consistently work, so this change swaps out the pip executable (if it's broken) for a small script that makes the call to python instead.