### PR TITLE
✨ Update comment to include macOS Monterey 12.1

### DIFF
--- a/mac-setup.sh
+++ b/mac-setup.sh
@@ -51,7 +51,7 @@ echo
 echo "Running Khan Installation Script 1.2"
 
 if ! sw_vers -productVersion 2>/dev/null | grep -q '10\.1[12345]\.' ; then
-    echo "Warning: This is only tested up to macOS 11.2 (Big Sur)."
+    echo "Warning: This is only tested up to macOS 12.1 (Monterey)."
     echo
     echo "If you find that this works on a newer version of macOS, "
     echo "please update this message."


### PR DESCRIPTION
## Summary:
The comment asked to be updated if the install worked on a later version of macOS. I was able to use it successfully with Monterey 12.1, hence the updated comment here.

Issue: "none"

## Test plan: