### PR TITLE
Update install-mac-mkcert.py to work with Firefox

### DIFF
--- a/bin/install-mac-mkcert.py
+++ b/bin/install-mac-mkcert.py
@@ -10,7 +10,8 @@ import subprocess
 
 result = subprocess.run(['which', 'mkcert'], capture_output=True)
 if result.returncode != 0:
-    subprocess.run(['brew', 'install', 'mkcert'], check=True)
+    # nss is a library that's required to make mkcert work with Firefox
+    subprocess.run(['brew', 'install', 'mkcert', 'nss'], check=True)
     # The following will ask for your password
     subprocess.run(['mkcert', '-install'], check=True)
 


### PR DESCRIPTION
## Summary:
Firefox doesn't work with `mkcert` unless the `nss` library has also been installed before running `mkcert -install`.  This PR updates dotfiles to include the `nss` library.

Issue: FEI-4346

## Test plan:
From the webapp folder run:
- `brew install mkcert nss`, see that it succeeds (it doesn't install anything on my system because both of these packages are already installed)
- `mkcert -install`
- `make -B genfiles/tlsproxy.pem` (this regenerates the certs)
- restart Firefox
- load `https://khanacademy.dev` in Firefox, see that it loads correctly (do the same for localhost:8088 when using ViteJS, this requires TLS as well)