### PR TITLE
install nss and mkcert as part of linux-setup.sh

### DIFF
--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -61,12 +61,8 @@ install_go() {
 # NOTE: This depends on `go` being installed.
 install_mkcert() {
     if ! which mkcert >/dev/null; then
-        builddir="/tmp/mkcert/"
-        if [ ! -d "$builddir" ]; then
-            mkdir -p "$builddir"
-            git clone https://github.com/FiloSottile/mkcert "$builddir"
-        fi
-
+        builddir=$(mktemp -d -t mkcert)
+        git clone https://github.com/FiloSottile/mkcert "$builddir"
         cd "$builddir"
         go build -ldflags "-X main.Version=$(git describe --tags)"
         sudo install -m 755 mkcert /usr/local/bin
@@ -247,11 +243,8 @@ install_protoc() {
 install_watchman() {
     if ! which watchman ; then
         update "Installing watchman..."
-        builddir="/tmp/watchman/"
-        if [ ! -d "$builddir" ]; then
-            mkdir -p "$builddir"
-            git clone https://github.com/facebook/watchman.git "$builddir"
-        fi
+        builddir=$(mktemp -d -t watchman)
+        git clone https://github.com/facebook/watchman.git "$builddir"
 
         (
             # Adapted from https://medium.com/@saurabh.friday/install-watchman-on-ubuntu-18-04-ba23c56eb23a

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -57,9 +57,17 @@ install_go() {
 # webapp:
 # - https://khanacademy.dev
 # - the "Vitejs Directly" option in the dev support bar
+#
+# NOTE: This depends on `go` being installed.
 install_mkcert() {
     if ! which mkcert >/dev/null; then
-        git clone https://github.com/FiloSottile/mkcert && cd mkcert
+        builddir="$DEVTOOLS_DIR/mkcert/"
+        if [ ! -d "$builddir" ]; then
+            mkdir -p "$builddir"
+            git clone https://github.com/FiloSottile/mkcert "$builddir"
+        fi
+
+        cd "$builddir"
         go build -ldflags "-X main.Version=$(git describe --tags)"
         sudo cp mkcert /usr/local/bin/mkcert
     else

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -61,7 +61,7 @@ install_go() {
 # NOTE: This depends on `go` being installed.
 install_mkcert() {
     if ! which mkcert >/dev/null; then
-        builddir="$DEVTOOLS_DIR/mkcert/"
+        builddir="/tmp/mkcert/"
         if [ ! -d "$builddir" ]; then
             mkdir -p "$builddir"
             git clone https://github.com/FiloSottile/mkcert "$builddir"
@@ -69,7 +69,7 @@ install_mkcert() {
 
         cd "$builddir"
         go build -ldflags "-X main.Version=$(git describe --tags)"
-        sudo cp mkcert /usr/local/bin/mkcert
+        sudo install -m 755 mkcert /usr/local/bin
     else
         echo "mkcert already installed"
     fi
@@ -247,7 +247,7 @@ install_protoc() {
 install_watchman() {
     if ! which watchman ; then
         update "Installing watchman..."
-        builddir="$DEVTOOLS_DIR/watchman/"
+        builddir="/tmp/watchman/"
         if [ ! -d "$builddir" ]; then
             mkdir -p "$builddir"
             git clone https://github.com/facebook/watchman.git "$builddir"

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -61,11 +61,18 @@ install_go() {
 # NOTE: This depends on `go` being installed.
 install_mkcert() {
     if ! which mkcert >/dev/null; then
+        update "Installing mkcert..."
         builddir=$(mktemp -d -t mkcert)
         git clone https://github.com/FiloSottile/mkcert "$builddir"
-        cd "$builddir"
-        go build -ldflags "-X main.Version=$(git describe --tags)"
-        sudo install -m 755 mkcert /usr/local/bin
+
+        (
+            cd "$builddir"
+            go build -ldflags "-X main.Version=$(git describe --tags)"
+            sudo install -m 755 mkcert /usr/local/bin
+        )
+
+        # cleanup temporary build directory
+        rm -rf "$builddir"
     else
         echo "mkcert already installed"
     fi
@@ -258,6 +265,9 @@ install_watchman() {
             make
             sudo make install
         )
+
+        # cleanup temporary build directory
+        rm -rf "$builddir"
     fi
 }
 


### PR DESCRIPTION
## Summary:
I recently made a tweak to install-mac-mkcert.py and assumed that no linux change was necessary because I couldn't find anything in the linux setup that was installing mkcert.  I assumed that this tool was part of the default ubuntu install.  How wrong I was.

This PR rectifies the situation by installing libnss3-tools which is a pre-req for mkcert and then builds mkcert for source before installing it.  The reason why I went the source route instead of downloading a pre-built binary from GitHub was to avoid potential architecture differences.  Also, the compile time is neglible.

I thought about reusing this function for the MacOS setup as well, but install_mkcert uses sudo for Linux, but on MacOS we'd want to run it without sudo, so ended up leaving the MacOS setup the way it is.

Issue: none

## Test plan:
- `sudo rm /usr/local/bin/mkcert` (from previous testing)
- copy the `install_mkcert` function, definition of `DEVTOOLS_DIR`, add a shebang, and a call to `install_mkcert` at the bottom
- `chmod 755 install_mkcert.sh`
- `./install_mkcert.sh`
- see it build and install mkcert
- `./install_mkcert.sh`
- see the `mkcert already installed` echoed
- run `mkcert -install` and see the following output (I've run it previous and don't know how to clear the trust store)
```
mkcert -install              
The local CA is already installed in the system trust store! 👍
The local CA is already installed in the Firefox trust store! 👍
```
- from webapp run `make -B genfiles/tlsproxy.pem` and see the following output:
```
mkcert \
		-cert-file genfiles/tlsproxy.pem \
		-key-file genfiles/tlsproxy-key.pem \
		"khanacademy.dev" "*.khanacademy.dev" \
		"khanacademy.test" "*.khanacademy.test" \
		"khanacademy.localhost" "*.khanacademy.localhost" \
		localhost 127.0.0.1 "::1"

Created a new certificate valid for the following names 📜
 - "khanacademy.dev"
 - "*.khanacademy.dev"
 - "khanacademy.test"
 - "*.khanacademy.test"
 - "khanacademy.localhost"
 - "*.khanacademy.localhost"
 - "localhost"
 - "127.0.0.1"
 - "::1"

Reminder: X.509 wildcards only go one level deep, so this won't match a.b.khanacademy.dev ℹ️

The certificate is at "genfiles/tlsproxy.pem" and the key at "genfiles/tlsproxy-key.pem" ✅

It will expire on 17 May 2024 🗓

# sync-end:dev-domains
```