### PR TITLE
[🔥AUDIT🔥] Fix mktemp calls

### DIFF
--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -62,7 +62,7 @@ install_go() {
 install_mkcert() {
     if ! which mkcert >/dev/null; then
         update "Installing mkcert..."
-        builddir=$(mktemp -d -t mkcert)
+        builddir=$(mktemp -d -t mkcert.XXXXX)
         git clone https://github.com/FiloSottile/mkcert "$builddir"
 
         (
@@ -250,7 +250,7 @@ install_protoc() {
 install_watchman() {
     if ! which watchman ; then
         update "Installing watchman..."
-        builddir=$(mktemp -d -t watchman)
+        builddir=$(mktemp -d -t watchman.XXXXX)
         git clone https://github.com/facebook/watchman.git "$builddir"
 
         (


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The named passed to 'mktemp' is supposed to include at least three X's.  It worked on MacOS without the X's, but this needs to work on Linux.

Issue: none

## Test plan:
- same test plan as #46