### PR TITLE
Set up certificate authority as party of Linux setup

### DIFF
--- a/bin/install-mac-mkcert.py
+++ b/bin/install-mac-mkcert.py
@@ -16,7 +16,9 @@ if result.returncode != 0:
     subprocess.run(['mkcert', '-install'], check=True)
 
     print("""
-You have installed mkcert (used to make khanacademy.dev work)
+You have installed mkcert (used to make khanacademy.dev and "Vitejs Directly"
+on localhost:8088 work).
+
 A CA has been added to your system and browser certificate trust stores.
 
 You must REBOOT your machine for browsers to recognize new CA.

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -73,6 +73,13 @@ install_mkcert() {
 
         # cleanup temporary build directory
         rm -rf "$builddir"
+
+        mkcert -install
+
+        echo "You have installed mkcert (used to make khanacademy.dev work)"
+        echo "A CA has been added to your system and browser certificate trust stores."
+        echo ""
+        echo "You must REBOOT your machine for browsers to recognize new CA."
     else
         echo "mkcert already installed"
     fi

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -76,8 +76,11 @@ install_mkcert() {
 
         mkcert -install
 
-        echo "You have installed mkcert (used to make khanacademy.dev work)"
-        echo "A CA has been added to your system and browser certificate trust stores."
+        echo "You have installed mkcert (used to make khanacademy.dev and "
+        echo "'Vitejs Directly' on localhost:8088 work)."
+        echo ""
+        echo "A CA has been added to your system and browser certificate "
+        echo "trust stores."
         echo ""
         echo "You must REBOOT your machine for browsers to recognize new CA."
     else

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -82,7 +82,9 @@ install_mkcert() {
         echo "A CA has been added to your system and browser certificate "
         echo "trust stores."
         echo ""
-        echo "You must REBOOT your machine for browsers to recognize new CA."
+        echo "You must RESTART your browser in order for it to recognize "
+        echo "the new CA and in some situations you may need REBOOT your "
+        echo "machine."
     else
         echo "mkcert already installed"
     fi


### PR DESCRIPTION
## Summary:
In #46 I added steps to linux-setup.sh to install 'mkcert', but didn't actually run 'mkcert -install' to set up the certificate authority like we do in install-mac-mkcert.py.  This PR rectifies the situation by update 'install_mkcert' to do this.  It also echos a message reminding people they'll need to reboot their machine.  I'm not sure if this is actually necessary on Linux though.

Issue: none

## Test plan:
- Same test plan as #46 except this time you should see output from 'mkcert -install' as well as the message saying to reboot the machine

```
$ chmod 755 install_mkcert.sh 
$ rm -rf /usr/local/bin/mkcert 
$ ./install_mkcert.sh 
./install_mkcert.sh: line 5: update: command not found
Cloning into '/var/folders/nc/zq7cwh1s5wd6njvp_89zt3d00000gn/T/mkcert.XXXXX.UyaXeUaz'...
remote: Enumerating objects: 717, done.
remote: Counting objects: 100% (3/3), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 717 (delta 0), reused 2 (delta 0), pack-reused 714
Receiving objects: 100% (717/717), 1.79 MiB | 6.31 MiB/s, done.
Resolving deltas: 100% (341/341), done.
Password:
The local CA is already installed in the system trust store! 👍
The local CA is already installed in the Firefox trust store! 👍

You have installed mkcert (used to make khanacademy.dev work)
A CA has been added to your system and browser certificate trust stores.

You must REBOOT your machine for browsers to recognize new CA.
$ ./install_mkcert.sh
mkcert already installed
```