### PR TITLE
Install python2 in cases where there's no system python2

### DIFF
--- a/bin/install-mac-python2.py
+++ b/bin/install-mac-python2.py
@@ -11,7 +11,8 @@ parser.add_argument("--force", help="Force install of Khan's python2",
 args = parser.parse_args()
 
 which = subprocess.run(['which', 'python2'], capture_output=True, text=True)
-is_installed = which.stdout.strip() != "/usr/bin/python2"
+is_installed = (which.returncode == 0
+                and which.stdout.strip() != "/usr/bin/python2")
 if is_installed:
     print("Already running a non-system python2.")
 


### PR DESCRIPTION
## Summary:
MacOS 12.3 no longer includes a system python 2. The dotfiles assumed that it did.
This instead checks the return code of `which python2` to see if no python2 is installed
at all (and then installs it in that case).

More detail:
https://khanacademy.slack.com/archives/C02NMB1R5/p1649879303389049?thread_ts=1649877395.083359&cid=C02NMB1R5
and
https://khanacademy.slack.com/archives/C02NMB1R5/p1649090083757979?thread_ts=1648850401.466419&cid=C02NMB1R5

Issue: XXX-XXXX

## Test plan:
Jonathan Price ran this on a fresh MacOS 12.3 and it worked.