### PR TITLE
INFRA-7843 - Move khan-dotfiles to node 16

### DIFF
--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -206,26 +206,26 @@ install_node() {
     [ `uname -m` = "arm64" ] && BREW="arch -x86_64 /usr/local/bin/brew"
 
     if ! which node >/dev/null 2>&1; then
-        # Install node 12: It's LTS and the latest version supported on
+        # Install node 16: It's LTS and the latest version supported on
         # appengine standard.
-        $BREW install node@12
+        $BREW install node@16
 
         # We need this because brew doesn't link /usr/local/bin/node
         # by default when installing non-latest node.
-        $BREW link --force --overwrite node@12
+        $BREW link --force --overwrite node@16
     fi
-    # We don't want to force usage of node v12, but we want to make clear we
+    # We don't want to force usage of node v16, but we want to make clear we
     # don't support anything else.
-    if ! node --version | grep "v12" >/dev/null ; then
-        notice "Your version of node is $(node --version). We currently only support v12."
-        if $BREW ls --versions node@12 >/dev/null ; then
-            notice "You do however have node 12 installed."
+    if ! node --version | grep "v16" >/dev/null ; then
+        notice "Your version of node is $(node --version). We currently only support v16."
+        if $BREW ls --versions node@16 >/dev/null ; then
+            notice "You do however have node 16 installed."
             notice "Consider running:"
         else
             notice "Consider running:"
-            notice "\t${tty_bold}brew install node@12${tty_normal}"
+            notice "\t${tty_bold}brew install node@16${tty_normal}"
         fi
-        notice "\t${tty_bold}brew link --force --overwrite node@12${tty_normal}"
+        notice "\t${tty_bold}brew link --force --overwrite node@16${tty_normal}"
         read -p "Press enter to continue..."
     fi
 }


### PR DESCRIPTION
Jenkins has been upgraded and it is now time to move everybody
forward to node 16.

Note: We install node-16 if there is no version of node inestalled.
However, if there is a version of node installed, we prompt the user
with commands to upgrade node in case they have a reason to stay at
a different version.

Issue: https://khanacademy.atlassian.net/browse/INFRA-7843

Test plan:

* Run `mac-setup-normal.sh` on a system with node 12 installed.
* Run `mac-setup-normal.sh` on a system without node installed.
