### PR TITLE
Dev 783

### DIFF
--- a/bin/bad_versions.txt
+++ b/bin/bad_versions.txt
@@ -1,0 +1,7 @@
+# This file contains known bad versions of software. It should be formatted as:
+# some version | the reason it's bad
+# The version should exactly match the output of the version command
+# Lines that start with a hash mark are ignored
+
+# Go
+go version go1.16.11 darwin/amd64 | This version of go has problems with linters, see DEV-783

--- a/bin/system_report.sh
+++ b/bin/system_report.sh
@@ -21,6 +21,14 @@ kv_multiline() {
     printf "%s\n%s\n\n" "$1:" "$2" >> "${tmpfile}"
 }
 
+tool_version_warning() {
+    version=$1
+    warning="$(grep -v '^#' bin/bad_versions.txt | grep "${version}" | sed 's/.* | //g')"
+    if ! [ -z "$warning" ] ; then
+        printf "\n!!! WARNING!!!\n\t %s" "${warning}" >> "${tmpfile}"
+    fi
+}
+
 tool_version() {
     tool=$1
     version_cmd=$2
@@ -29,7 +37,9 @@ tool_version() {
         if [[ -L "${loc}" ]] ; then
             loc="${loc} -> $(readlink "${loc}")"
         fi
-        kv "${tool}" "$("${tool}" "${version_cmd}" 2>&1) (${loc})"
+        version="$("${tool}" "${version_cmd}" 2>&1)"
+        kv "${tool}" "${version} (${loc})"
+        tool_version_warning "${version}"
     else
         kv "${tool}" "Not present!"
     fi

--- a/bin/system_report.sh
+++ b/bin/system_report.sh
@@ -61,9 +61,8 @@ if [ "${uname_os}" = "Darwin" ]; then
     # Should be 10.15.x or 11.x
     osx_version=$(sw_vers -productVersion)
     kv "Version" "${osx_version}"
-    # We support EXACTLY 10.15.x and 11.x.x
-    if echo "$osx_version" | grep -q -v -e '^10.15' -e '^11' ; then 
-        kv "!!! WARNING!!!" "Please update to OSX 10.15 Catalina!!!"
+    if echo "$osx_version" | grep -q -v -e '^12' -e '^11' ; then 
+        kv "!!! WARNING!!!" "Please update to OSX 12(Monterey)!!!"
 
     fi
 fi

--- a/bin/system_report.sh
+++ b/bin/system_report.sh
@@ -79,7 +79,7 @@ kv "PATH" "$PATH"
 if [ "${uname_os}" = "Darwin" ]; then
     header "OSX - XCode"
     # DEV-245 - Should be 11.x
-    kv_multiline "Xcode Version" "$(xcodebuild -version)"
+    kv_multiline "Xcode Version" "$(xcodebuild -version 2>&1)"
     kv_multiline "Avaliable Versions" "$(system_profiler SPDeveloperToolsDataType)"
 fi
 


### PR DESCRIPTION
In DEV-783 we had a problem with a version of go not correctly supporting the plugin system, which causes problems for our `golangci-lint` tooling. That problem was obfuscated by a warning about xcode (a common pain point) that was actually a red herring.

Here we detect the known bad version of go (as well as set up some framework for detecting known-bad versions again in the future) and put the `xcodebuild` error messaging in the report rather than on the command line, so it can be correctly dealt with IF (and preferably only if) it is actually a problem.

Test Plan:
1. Run `system_report.sh` to verify it works correctly.
2. Modify the version of go to validate it detects bad versions correctly: 
```sh
    Go:
go:                  go version go1.16.13 darwin/amd64 (/usr/local/bin/go -> ../Cellar/go@1.16/1.16.13/bin/go)

!!! WARNING!!!
	 This version of go has problems with linters, see DEV-783
```
3. Had @jeffkhan run the script from the topic branch, xcode reports for him: 
```sh
    OSX - XCode:
Xcode Version:
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
```