### PR TITLE
Prefer x86 version of go on ARM architecture.

### DIFF
--- a/.bash_profile.khan
+++ b/.bash_profile.khan
@@ -40,3 +40,8 @@ if ! which gcloud >/dev/null; then
         source "$GCLOUD_COMPLETION_FILE"
     fi
 fi
+
+# Add a brew86 alias if we're on an ARM architecture Mac
+if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+  alias brew86="arch -x86_64 /usr/local/bin/brew $@"
+fi


### PR DESCRIPTION
## Summary:
Localproxy uses a library, `wasmtime-go`, which is presently does not distribute an ARM architecture go binary, preventing it from running without a number of extra steps.

For now, the easiest thing to do is to always install the ARM architecture version instead.

This also switching the node install to use the same brew86 function, and installs a brew86 alias in the dotfiles if on an ARM architecture Mac.

Issue: INFRA-7969

## Test plan:
Uninstall go
Run `make`
Verify the go is installed, and is version `1.16.x darwin/amd64` (not `darwin/arm64`)