### PR TITLE
Update go.mod for mkcert before trying to build it.

### DIFF
--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -67,6 +67,7 @@ install_mkcert() {
 
         (
             cd "$builddir"
+            go mod download
             go build -ldflags "-X main.Version=$(git describe --tags)"
             sudo install -m 755 mkcert /usr/local/bin
         )


### PR DESCRIPTION
## Summary:
go1.16 changed the way modules work to require you to download modules
explicitly in your repo.  Now that we're on go1.16, we need to use
this new protoco when building mkcert.  Without it, the build fails
with the error:
```
$ go build -ldflags "-X main.Version=$(git describe --tags)"
go: golang.org/x/net@v0.0.0-20220421235706-1d1ef9303861 requires
        golang.org/x/sys@v0.0.0-20211216021012-1d35b9e2eb4e: missing go.sum entry; to add it:
        go mod download golang.org/x/sys
```

Issue: none

## Test plan:
Ran the command manually on my local linux machine with success.