### PR TITLE
Use Bundler to install Fastlane/Cocoapods

### DIFF
--- a/mac-ios-setup.sh
+++ b/mac-ios-setup.sh
@@ -55,7 +55,7 @@ install_carthage() {
 
 install_fastlane() {
     update "Installing Fastlane and Cocoapods..."
-    (cd "$REPOS_DIR/mobile"; bundle install)
+    (cd "$REPOS_DIR/mobile/ios"; bundle install)
 }
 
 ensure_mac_os # Function defined in shared-functions.sh.

--- a/mac-ios-setup.sh
+++ b/mac-ios-setup.sh
@@ -54,15 +54,8 @@ install_carthage() {
 }
 
 install_fastlane() {
-    if ! which fastlane; then
-        update "Installing fastlane..."
-        sudo gem install fastlane --no-document --verbose
-
-        # Make sure the gem install dir is in our PATH
-        if ! command -v fastlane &>/dev/null; then
-            echo "export PATH=$(gem environment gemdir)/bin:$PATH" >>~/.bash_profile
-        fi
-    fi
+    update "Installing Fastlane and Cocoapods..."
+    (cd "$REPOS_DIR/mobile"; bundle install)
 }
 
 ensure_mac_os # Function defined in shared-functions.sh.

--- a/mobile-functions.sh
+++ b/mobile-functions.sh
@@ -27,5 +27,5 @@ clone_mobile_repo() {
 
 install_react_native_dependencies() {
     update "Installing react-native dependencies..."
-    (cd "$REPOS_DIR/mobile/ios"; yarn)
+    (cd "$REPOS_DIR/mobile"; yarn)
 }

--- a/mobile-functions.sh
+++ b/mobile-functions.sh
@@ -27,5 +27,5 @@ clone_mobile_repo() {
 
 install_react_native_dependencies() {
     update "Installing react-native dependencies..."
-    (cd "$REPOS_DIR/mobile"; yarn)
+    (cd "$REPOS_DIR/mobile/ios"; yarn)
 }


### PR DESCRIPTION
## Summary:

We recently changed the mobile repo to use Ruby's Bundler to install our Ruby-based tools (Fastlane and CocoaPods). This PR updates the dotfiles to also use Bundler when installing Fastlane/Cocoapods.

Issue: "none"

## Test plan:

Run `mac-ios-setup.sh`
Switch to mobile repo: `cd ~/khan/mobile/ios`
Run fastlane: `bundle exec fastlane --help` (you should get Fastlane help info which verifies that Fastlane is installed)