### PR TITLE
Add CGO_CPPFLAGS to avoid macro expansion error on some macs

### DIFF
--- a/.profile.khan
+++ b/.profile.khan
@@ -99,6 +99,7 @@ if [ `uname -s` = Darwin ]; then
     export LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS"
     export CPPFLAGS="-I/usr/local/opt/openssl/include $CPPFLAGS"
     export CFLAGS="-I/usr/local/include -L/usr/local/lib $CFLAGS"
+    export CGO_CPPFLAGS="-Wno-error -Wno-nullability-completeness -Wno-expansion-to-defined -Wno-builtin-requires-header" $CGO_CPPFLAGS
 
     # We use the timeout command a lot, but os x calls it `gtimeout`.
     alias timeout=gtimeout

--- a/bin/system_report.sh
+++ b/bin/system_report.sh
@@ -108,6 +108,7 @@ tool_version yarn --version
 
 header "Go"
 tool_version go version
+kv_multiline "Go ENV" "$(go env)"
 
 header "Rust"
 tool_version cargo --version


### PR DESCRIPTION
## Summary:
In DEV-821, we see there are some problems with compiling plugins for the golangci-lint system as a result of some changes in XCode's clang library. This is at least the second time our engineers have dealt with this.

Here we fix the problem by exporting in the profile a set of flags that will explicitly modify the way clang is used when compiling go binaries, specifically by adjusting CGO_CPPFLAGS. This should have no impact on how any non-go program uses clang, and further because the majority (all?) of our production services do not use CGO, should have no impact on locally running services other than CLI utilities. This will also not modify how the services themselves are build for prod, as these dotfiles are not how we set up the machines.

Lastly, per https://clang.llvm.org/docs/ClangCommandLineReference.html#preprocessor-flags it appears that all flags of the form `-Wno-...` are actually disabling a warning from being raised as an error. Since all the flags exported here are of that format, it seems reasonable to assume that this is safe. Ideally, the maintainers of the go plugin library could address this better, but for now this seems sufficient.

Lastly, this adds a `go env` check to the `system_report.sh` script so that we can see if these values (as well as other relevant go environment values) are set when attempting to troubleshoot dev machines.

Issue: DEV-821

## Test plan:
1. Run on local machine
2. Ask engineer to update to this branch and recompile the *.so golangci-lint plugins with this
3. Run `system_report.sh` to validate they are set correctly