### PR TITLE
Improve Linux setup scripts

### DIFF
--- a/.profile.khan
+++ b/.profile.khan
@@ -117,6 +117,7 @@ if [ -z "$DO_NOT_ACTIVATE_VIRTUALENV_KHAN27" ]; then
     # This is desireable if you're touching the python monolith
     if [ -s ~/.virtualenv/khan27/bin/activate ]; then
         . ~/.virtualenv/khan27/bin/activate
+        export CLOUDSDK_PYTHON=~/.virtualenv/khan27/bin/python
     else
         echo "[WARN]  Could not find '~/.virtualenv/khan27/bin/activate'"\
           "- All processes that depend on Python may be negatively impacted."\

--- a/.profile.khan
+++ b/.profile.khan
@@ -114,9 +114,12 @@ fi
 #
 if [ -z "$DO_NOT_ACTIVATE_VIRTUALENV_KHAN27" ]; then
     # Activate Python2.7 virtualenv if present
-    # This is desireable if you're touching the python monolith
+    # This is desirable if you're touching the python monolith
     if [ -s ~/.virtualenv/khan27/bin/activate ]; then
         . ~/.virtualenv/khan27/bin/activate
+        # Force gcloud to use Python 2.7, since our version of the SDK doesn't
+        # work with Python 3.10+.
+        # TODO: Remove this when we upgrade the gcloud SDK to at least 377.0.0.
         export CLOUDSDK_PYTHON=~/.virtualenv/khan27/bin/python
     else
         echo "[WARN]  Could not find '~/.virtualenv/khan27/bin/activate'"\

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -201,7 +201,7 @@ EOF
         libxslt1-dev \
         libyaml-dev \
         libncurses-dev libreadline-dev \
-        nodejs=16* \
+        nodejs \
         nginx \
         redis-server \
         unzip \
@@ -221,7 +221,7 @@ EOF
     # npm version is 5.x.x, 6.x.x, or 7.x.x.
     if expr "`npm --version`" : '5\|6\|7' >/dev/null 2>&1; then
         sudo apt-get purge -y nodejs
-        sudo apt-get install -y "nodejs=16*"
+        sudo apt-get install -y "nodejs"
     fi
 
     # Ubuntu installs as /usr/bin/nodejs but the rest of the world expects

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -291,9 +291,11 @@ install_watchman() {
 install_postgresql() {
     # Instructions taken from
     # https://pgdash.io/blog/postgres-11-getting-started.html
+    # and
+    # https://wiki.postgresql.org/wiki/Apt
     # Postgres 11 is not available in 18.04, so we need to add the pg apt repository.
-    curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-        | sudo apt-key add -
+    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+        | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
 
     sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -c -s`-pgdg main"
     sudo apt-get update

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -331,9 +331,11 @@ install_postgresql() {
 install_rust() {
     builddir=$(mktemp -d -t rustup.XXXXX) 
 
-    cd "$builddir"
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup-init.sh
-    bash rustup-init.sh -y --profile default
+    (
+        cd "$builddir"
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup-init.sh
+        bash rustup-init.sh -y --profile default
+    )
 
     # cleanup temporary build directory
     sudo rm -rf "$builddir"

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -328,6 +328,17 @@ install_postgresql() {
     sudo service postgresql restart
 }
 
+install_rust() {
+    builddir=$(mktemp -d -t rustup.XXXXX) 
+
+    cd "$builddir"
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup-init.sh
+    bash rustup-init.sh -y --profile default
+
+    # cleanup temporary build directory
+    sudo rm -rf "$builddir"
+}
+
 setup_clock() {
     # This shouldn't be necessary, but it seems it is.
     if ! grep -q 3.ubuntu.pool.ntp.org /etc/ntp.conf; then
@@ -370,6 +381,7 @@ install_watchman
 setup_clock
 config_inotify
 install_postgresql
+install_rust
 # TODO (boris): Setup pyenv (see mac_setup:install_python_tools)
 # https://opencafe.readthedocs.io/en/latest/getting_started/pyenv/
 

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -299,7 +299,7 @@ install_postgresql() {
 
     sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -c -s`-pgdg main"
     sudo apt-get update
-    sudo apt-get install -y postgresql-11 postgresql-contrib libpq-dev
+    sudo apt-get install -y postgresql-11
 
     # Set up authentication to allow connections from the postgres user with no
     # password. This matches the authentication setup that homebrew installs on

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -150,6 +150,9 @@ EOF
     # This is needed for ubuntu >=20, but not prior ones.
     sudo apt-get install -y python-is-python2 || true
 
+    # Python is needed for development and curl is needed for the setup scripts
+    sudo apt-get install -y python-dev python-mode python-setuptools curl
+
     # Install pip manually.
     curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
     sudo python2 get-pip.py
@@ -163,7 +166,7 @@ EOF
     sudo pip install virtualenv==20.0.23
     sudo pip install http://sourceforge.net/projects/pychecker/files/pychecker/0.8.19/pychecker-0.8.19.tar.gz/download
 
-    # Needed to develop at Khan: git, python, node (js).
+    # Needed to develop at Khan: git, node (js).
     # php is needed for phabricator
     # lib{freetype6{,-dev},{png,jpeg}-dev} are needed for PIL
     # imagemagick is needed for image resizing and other operations
@@ -172,15 +175,11 @@ EOF
     # libncurses-dev and libreadline-dev are needed for readline
     # nginx is used as a devserver proxy that serves static files
     # nodejs is used for various frontendy stuff in webapp, as well as our js
-    #   services. We standardize on version 12 (the latest version suppported
-    #   on appengine standard).
+    #   services. We standardize on version 16.
     # redis is needed to run memorystore on dev
     # libnss3-tools is a pre-req for mkcert, see install_mkcert for details.
     # TODO(benkraft): Pull the version we want from webapp somehow.
-    # curl for various scripts (including setup.sh)
     sudo apt-get install -y git \
-        python-dev \
-        python-mode python-setuptools \
         libfreetype6 libfreetype6-dev libpng-dev libjpeg-dev \
         imagemagick \
         libxslt1-dev \
@@ -189,10 +188,10 @@ EOF
         nodejs=16* \
         nginx \
         redis-server \
-        curl \
         unzip \
         jq \
-        libnss3-tools
+        libnss3-tools \
+        python3-pip
 
     # There are two different php packages, depending on if you're on Ubuntu
     # 14.04 LTS or 16.04 LTS, and neither version has both.  So we just try
@@ -231,7 +230,7 @@ EOF
     sudo apt-get install -y unrar virtualbox ack-grep
 
     # Not needed for Khan, but useful things to have.
-    sudo apt-get install -y ntp abiword curl diffstat expect gimp \
+    sudo apt-get install -y ntp abiword diffstat expect gimp \
         mplayer netcat netpbm screen w3m vim emacs google-chrome-stable
 
     # If you don't have the other ack installed, ack is shorter than ack-grep

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -155,16 +155,21 @@ EOF
 
     # Install pip manually.
     curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
-    sudo python2 get-pip.py
+    # Match webapp's version.
+    sudo python2 get-pip.py pip==19.3.1
     # Delete get-pip.py after we're finish running it.
     rm -f get-pip.py
-    # Match webapp's version.
-    sudo pip install pip==19.3.1
 
     # Install virtualenv and pychecker manually; ubuntu
     # dropped support for them in ubuntu >=20 (since they're python2)
     sudo pip install virtualenv==20.0.23
     sudo pip install http://sourceforge.net/projects/pychecker/files/pychecker/0.8.19/pychecker-0.8.19.tar.gz/download
+
+    # get-pip.py will remove the system pip3 binary if it previously existed,
+    # but it won't remove the package, so installing the package again won't
+    # restore it. Here we remove the package if it exists, so that the next
+    # apt-get command will install it properly.
+    sudo apt-get remove -y python3-pip || true
 
     # Needed to develop at Khan: git, node (js).
     # php is needed for phabricator

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -109,19 +109,19 @@ install_packages() {
         updated_apt_repo=yes
     fi
     if ! ls /etc/apt/sources.list.d/ 2>&1 | grep -q nodesource || \
-       ! grep -q node_12.x /etc/apt/sources.list.d/nodesource.list; then
-        # This is a simplified version of https://deb.nodesource.com/setup_12.x
+       ! grep -q node_16.x /etc/apt/sources.list.d/nodesource.list; then
+        # This is a simplified version of https://deb.nodesource.com/setup_16.x
         wget -O- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
         cat <<EOF | sudo tee /etc/apt/sources.list.d/nodesource.list
-deb https://deb.nodesource.com/node_12.x `lsb_release -c -s` main
-deb-src https://deb.nodesource.com/node_12.x `lsb_release -c -s` main
+deb https://deb.nodesource.com/node_16.x `lsb_release -c -s` main
+deb-src https://deb.nodesource.com/node_16.x `lsb_release -c -s` main
 EOF
         sudo chmod a+rX /etc/apt/sources.list.d/nodesource.list
 
-        # Pin nodejs to 12.x, otherwise apt will update newer Ubuntu versions
+        # Pin nodejs to 16.x, otherwise apt might update it in newer Ubuntu versions
         cat <<EOF | sudo tee /etc/apt/preferences.d/nodejs
 Package: nodejs
-Pin: version 12.*
+Pin: version 16.*
 Pin-Priority: 999
 EOF
         updated_apt_repo=yes
@@ -155,7 +155,7 @@ EOF
     sudo python2 get-pip.py
     # Delete get-pip.py after we're finish running it.
     rm -f get-pip.py
-    # Match webapp's version version.
+    # Match webapp's version.
     sudo pip install pip==19.3.1
 
     # Install virtualenv and pychecker manually; ubuntu
@@ -186,7 +186,7 @@ EOF
         libxslt1-dev \
         libyaml-dev \
         libncurses-dev libreadline-dev \
-        nodejs=12* \
+        nodejs=16* \
         nginx \
         redis-server \
         curl \
@@ -200,13 +200,13 @@ EOF
     # need too.
     sudo apt install -y php-cli php-curl php-xml || sudo apt-get install -y php5-cli php5-curl
 
-    # We need npm 6 or greater to support node12.  That's the default
+    # We need npm 8 or greater to support node16.  That's the default
     # for nodejs, but we may have overridden it before in a way that
     # makes it impossible to upgrade, so we reinstall nodejs if our
-    # npm version is 5.x.x.
-    if expr "`npm --version`" : 5 >/dev/null 2>&1; then
+    # npm version is 5.x.x, 6.x.x, or 7.x.x.
+    if expr "`npm --version`" : '5\|6\|7' >/dev/null 2>&1; then
         sudo apt-get purge -y nodejs
-        sudo apt-get install -y "nodejs=12*"
+        sudo apt-get install -y "nodejs=16*"
     fi
 
     # Ubuntu installs as /usr/bin/nodejs but the rest of the world expects
@@ -223,9 +223,9 @@ EOF
     fi
     # Make sure we have the preferred version of npm
     # TODO(benkraft): Pull this version number from webapp somehow.
-    # We need npm 6 or greater to support node12. This is a particular npm6
+    # We need npm 8 or greater to support node16. This is a particular npm8
     # version known to work.
-    sudo npm install -g npm@6.14.4
+    sudo npm install -g npm@8.11.0
 
     # Not technically needed to develop at Khan, but we assume you have it.
     sudo apt-get install -y unrar virtualbox ack-grep

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -334,7 +334,7 @@ install_rust() {
     (
         cd "$builddir"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs --output rustup-init.sh
-        bash rustup-init.sh -y --profile default
+        bash rustup-init.sh -y --profile default --no-modify-path
     )
 
     # cleanup temporary build directory

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -284,7 +284,7 @@ install_watchman() {
         )
 
         # cleanup temporary build directory
-        rm -rf "$builddir"
+        sudo rm -rf "$builddir"
     fi
 }
 

--- a/setup-gcloud.sh
+++ b/setup-gcloud.sh
@@ -53,6 +53,8 @@ PATH="$DEVTOOLS_DIR/google-cloud-sdk/bin:$PATH"
 
 echo "$SCRIPT: Using DEVTOOLS_DIR=${DEVTOOLS_DIR}"
 
+# TODO: Remove the CLOUDSDK_PYTHON environment variable from .profile.khan
+#       and setup.sh when we upgrade the SDK version to at least 377.0.0.
 version=360.0.0  # should match webapp's MAX_SUPPORTED_VERSION
 if ! which gcloud >/dev/null; then
     echo "$SCRIPT: Installing Google Cloud SDK (gcloud)"

--- a/setup.sh
+++ b/setup.sh
@@ -223,6 +223,9 @@ setup_python() {
     pip3 install -q pipenv
 
     create_and_activate_virtualenv "$ROOT/.virtualenv/khan27"
+    # Force gcloud to use Python 2.7, since our version of the SDK doesn't
+    # work with Python 3.10+.
+    # TODO: Remove this when we upgrade the gcloud SDK to at least 377.0.0.
     export CLOUDSDK_PYTHON=~/.virtualenv/khan27/bin/python
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -210,9 +210,9 @@ clone_repos() {
     kaclone_repair_self
 }
 
-# Must have cloned the repos first.
-install_deps() {
-    echo "Installing virtualenv and any global dependencies"
+# Sets up Python 2, pipenv, and virtualenv
+setup_python() {
+    echo "Installing virtualenv"
 
     # Install virtualenv.
     # https://docs.google.com/document/d/1zrmm6byPImfbt7wDyS8PpULwnEckSxna2jhSl38cWt8
@@ -223,6 +223,12 @@ install_deps() {
     pip3 install -q pipenv
 
     create_and_activate_virtualenv "$ROOT/.virtualenv/khan27"
+    export CLOUDSDK_PYTHON=~/.virtualenv/khan27/bin/python
+}
+
+# Must have cloned the repos first.
+install_deps() {
+    echo "Installing global dependencies"
 
     # Need to install yarn first before run `make install_deps`
     # in webapp.
@@ -313,11 +319,12 @@ update_userinfo
 
 # the order for these is (mostly!) important, beware
 clone_repos
-install_and_setup_gcloud
-install_deps        # pre-reqs: clone_repos, install_and_setup_gcloud
-install_hooks       # pre-req: clone_repos
-download_db_dump    # pre-req: install_deps
-create_pg_databases # pre-req: install_deps
+setup_python
+install_and_setup_gcloud # pre-req: setup_python
+install_deps             # pre-reqs: clone_repos, install_and_setup_gcloud
+install_hooks            # pre-req: clone_repos
+download_db_dump         # pre-req: install_deps
+create_pg_databases      # pre-req: install_deps
 
 
 echo

--- a/setup.sh
+++ b/setup.sh
@@ -210,7 +210,7 @@ clone_repos() {
     kaclone_repair_self
 }
 
-# Sets up Python 2, pipenv, and virtualenv
+# Sets up virtualenv and pipenv
 setup_python() {
     echo "Installing virtualenv"
 


### PR DESCRIPTION
## Summary:
This commit fixes various issues that existed when running the dotfiles on Linux:

- The version of the Google Cloud SDK that is installed does not run under Python 3.10, which is the default Python version in Ubuntu 22.04. This commit includes a change to run the gcloud SDK under Python 2.7: it sets the `CLOUDSDK_PYTHON` environment variable to the khan27 virtualenv, which also requires setting up the virtualenv before installing the gcloud SDK.
- The scripts previously installed Node 12, which is no longer supported. This commit updates them to install Node 16 and NPM 8.
- The scripts previously used `curl` before installing it. This commit moves the curl installation to before its usage.
- The setup.sh script used `pip3`, but it wasn't being installed on Linux. This commit installs the `python3-pip` package and makes sure the `pip3` binary gets restored when it is removed by `get-pip.py`.
- The scripts used to install pip at the latest version, then revert it to 19.3.1. This commit changes the `get-pip.py` call to pass in the correct version during initial installation.
- The method for adding the PostgreSQL repo key no longer worked, so this commit changes to the method recommended on the postgresql.org wiki.
- The scripts previously installed the `postgresql-contrib` and `libpq-dev` packages, which weren't versioned to PostgreSQL 11. This caused a duplicate PostgreSQL server to be installed (version 14 in Ubuntu 22.04), which caused problems when setting up the database. This commit removes those packages, which weren't needed anyway, so now only PostgreSQL 11 is installed.
- Cleaning up the watchman build directory was failing previously, because `make install` created files in it that were owned by root. This commit cleans up the directory with `sudo` so those files can be deleted.
- The Python 2 package names have changed in Ubuntu 22.04, so this commit changes the scripts to try both the old and new package names.
- The `python-is-python2` package has been removed in Ubuntu 22.04, so the scripts will now manually add a symlink to the python2 binary if needed.
- There has been a `watchman` package in the official repos since Ubuntu 20.04, so the scripts will now first try installing it with apt-get and only build from source if that doesn't work.
- Previously Rust wasn't being installed by the Linux setup scripts, so this commit adds Rust installation. Note: the method implemented using the `rustup-init.sh` script will probably also work on MacOS, so we might be able to unify the two installation methods, but I didn't try it.

Issue: none

## Test plan:
- On clean installations of Ubuntu 18.04, 20.04, and 22.04, run `make` in the `khan-dotfiles` directory. Verify that the scripts run to completion without error.
- On Ubuntu 22.04, run `make fix_deps` and `make serve` in the webapp directory and load `http://localhost:8088/`. Switch the frontend source to ViteJS. Verify that the page loads correctly.
- On a Linux installation with Node 12, run the dotfiles scripts and verify that node is upgraded to version 16.