### PR TITLE
Install `fastly`, the fastly-cli

### DIFF
--- a/bin/system_report.sh
+++ b/bin/system_report.sh
@@ -113,6 +113,9 @@ kv_multiline "Go ENV" "$(go env)"
 header "Rust"
 tool_version cargo --version
 
+header "Fastly"
+tool_version fastly version
+
 header "PostgreSQL"
 tool_version postgres --version
 tool_version psql --version

--- a/bin/system_report.sh
+++ b/bin/system_report.sh
@@ -113,6 +113,7 @@ kv_multiline "Go ENV" "$(go env)"
 header "Rust"
 tool_version cargo --version
 
+# This is multi-line, but it's still pretty readable. Good enough for now.
 header "Fastly"
 tool_version fastly version
 

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -333,6 +333,19 @@ install_rust() {
     sudo rm -rf "$builddir"
 }
 
+install_fastly() {
+    builddir=$(mktemp -d -t fastly.XXXXX) 
+
+    (
+        cd "$builddir"
+        curl -LO https://github.com/fastly/cli/releases/download/v3.3.0/fastly_3.3.0_linux_amd64.deb
+        sudo apt install ./fastly_3.3.0_linux_amd64.deb
+    )
+
+    # cleanup temporary build directory
+    sudo rm -rf "$builddir"
+}
+
 setup_clock() {
     # This shouldn't be necessary, but it seems it is.
     if ! grep -q 3.ubuntu.pool.ntp.org /etc/ntp.conf; then
@@ -376,6 +389,7 @@ setup_clock
 config_inotify
 install_postgresql
 install_rust
+install_fastly
 # TODO (boris): Setup pyenv (see mac_setup:install_python_tools)
 # https://opencafe.readthedocs.io/en/latest/getting_started/pyenv/
 

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -338,6 +338,7 @@ install_fastly() {
 
     (
         cd "$builddir"
+        # There's no need to update the version regularly, fastly self updates
         curl -LO https://github.com/fastly/cli/releases/download/v3.3.0/fastly_3.3.0_linux_amd64.deb
         sudo apt install ./fastly_3.3.0_linux_amd64.deb
     )

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -372,6 +372,13 @@ install_watchman() {
     fi
 }
 
+install_fastly() {
+    if ! which fastly >/dev/null 2>&1; then
+        update "Installing fastly..."
+        brew install fastly/tap/fastly
+    fi
+}
+
 echo
 success "Running Khan mac-setup-normal.sh\n"
 
@@ -397,5 +404,6 @@ install_image_utils
 install_helpful_tools
 install_watchman
 install_python_tools
+install_fastly
 
 trap - EXIT


### PR DESCRIPTION
## Summary:
In order to use the new `fastly-khanacademy-dev` service, we'll need devs to have the `fastly` client. This installs it.

This also adds the version to the `system_report.sh` script

Issue: "none"

## Test plan:
1. Run `make`
2. Run `system_report.sh`