### PR TITLE
Install the age file encryption tool

### DIFF
--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -358,8 +358,8 @@ install_age() {
 
     if ! which age ; then
         # If installing the package didn't work, then download the binary.
-
         downloaddir=$(mktemp -d -t age.XXXXX)
+
         (
             cd "$downloaddir"
             curl -L https://dl.filippo.io/age/latest?for=linux/amd64 --output age.tar.gz
@@ -369,7 +369,7 @@ install_age() {
         )
 
         # cleanup temporary download directory
-        sudo rm -rf "downloaddir"
+        sudo rm -rf "$downloaddir"
     fi
 }
 

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -347,6 +347,32 @@ install_fastly() {
     sudo rm -rf "$builddir"
 }
 
+install_age() {
+    if ! which age ; then
+        update "Installing age..."
+
+        # First try installing via apt package, which exists in the repositories
+        # as of Ubuntu 22.04.
+        sudo apt-get install -y age || true
+    fi
+
+    if ! which age ; then
+        # If installing the package didn't work, then download the binary.
+
+        downloaddir=$(mktemp -d -t age.XXXXX)
+        (
+            cd "downloaddir"
+            curl -L https://dl.filippo.io/age/latest?for=linux/amd64 --output age.tar.gz
+            tar xf age.tar.gz
+            sudo mv ./age/age /usr/local/bin/
+            sudo mv ./age/age-keygen /usr/local/bin/
+        )
+
+        # cleanup temporary download directory
+        sudo rm -rf "downloaddir"
+    fi
+}
+
 setup_clock() {
     # This shouldn't be necessary, but it seems it is.
     if ! grep -q 3.ubuntu.pool.ntp.org /etc/ntp.conf; then
@@ -391,6 +417,7 @@ config_inotify
 install_postgresql
 install_rust
 install_fastly
+install_age
 # TODO (boris): Setup pyenv (see mac_setup:install_python_tools)
 # https://opencafe.readthedocs.io/en/latest/getting_started/pyenv/
 

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -361,7 +361,7 @@ install_age() {
 
         downloaddir=$(mktemp -d -t age.XXXXX)
         (
-            cd "downloaddir"
+            cd "$downloaddir"
             curl -L https://dl.filippo.io/age/latest?for=linux/amd64 --output age.tar.gz
             tar xf age.tar.gz
             sudo mv ./age/age /usr/local/bin/

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -337,6 +337,16 @@ install_openssl() {
     done
 }
 
+install_age() {
+    info "Checking for age\n"
+    if ! which age  >/dev/null 2>&1; then
+        info "Installing age\n"
+        brew install age
+    else
+        success "age already installed"
+    fi
+}
+
 install_jq() {
     info "Checking for jq\n"
     if ! which jq  >/dev/null 2>&1; then
@@ -387,6 +397,7 @@ maybe_generate_ssh_keys
 register_ssh_keys
 install_wget
 install_openssl
+install_age
 install_jq
 update_git
 


### PR DESCRIPTION
## Summary:
Instead of using openssl to encrypt secrets.py, we will use age
in the future, which has a better file format and is easier to
install.

Issue: none

## Test plan:
- Run the dotfiles on Linux 22.04, 20.04, and MacOS.