### PR TITLE
Add `git prs` as an alias for `git pull-requests`

### DIFF
--- a/.gitconfig.khan
+++ b/.gitconfig.khan
@@ -27,6 +27,7 @@
   rb = !git review-branch
   pb = !git review-branch       ; short for 'phabricator branch'
   pr = !git pull-request
+  prs = !git pull-requests
 
   # Other useful commands.
   outgoing = "!git fetch >/dev/null 2>&1; git log @{upstream}..HEAD"


### PR DESCRIPTION
## Summary:
https://github.com/Khan/our-lovely-cli/pull/530 added a git
pull-requests command to OLC. This adds an alias for it that's easier to
type.

Issue: none

Test plan:

Run `git prs`. You should see a report of your outstanding pull
requests.