### PR TITLE
Upgrade to Postgresql 14 from 11, along with mac update script

### DIFF
--- a/bin/mac-setup-postgres.py
+++ b/bin/mac-setup-postgres.py
@@ -13,7 +13,7 @@
 # may be useful to use homebrew to install python3 before running python3
 # scripts.
 
-# TODO(ericbrown): Why do we support anything other than postgresql@11 ?
+# TODO(ericbrown): Why do we support anything other than postgresql@14 ?
 # TODO(ericbrown): mac-setup.sh used to tweak icu4c - obsolete now?
 
 import os
@@ -22,15 +22,15 @@ import subprocess
 import time
 
 SCRIPT = os.path.basename(__file__)
-POSTGRES11_FORMULA = 'postgresql@11'
+POSTGRES_FORMULA = 'postgresql@14'
 
 
 def get_brewname():
     """Return the brew formula name currently installed or None."""
-    result = subprocess.run(['brew', 'ls', POSTGRES11_FORMULA],
+    result = subprocess.run(['brew', 'ls', POSTGRES_FORMULA],
                             capture_output=True)
     if result.returncode == 0:
-        return POSTGRES11_FORMULA
+        return POSTGRES_FORMULA
 
     # TODO(ericbrown): Remove when sure this is no longer needed
     # I believe this code is from when postgresql 11 was the current version
@@ -50,8 +50,8 @@ def link_postgres_if_needed(brewname: str, force=False):
     allowing postgresql and commands like psql to be found."""
 
     # TODO(ericbrown): If user has non-brew psql installed in PATH, WARN
-    # TODO(ericbrown): Verify this psql is from brew's postgresql@11
-    # If it is from postgresql@11 then we must either unlink or remove it
+    # TODO(ericbrown): Verify this psql is from brew's postgresql@14
+    # If it is from postgresql@14 then we must either unlink or remove it
     result = subprocess.run(['which', 'psql'], capture_output=True)
     if force or result.returncode != 0:
         print(f'{SCRIPT}: brew link {brewname}')
@@ -105,10 +105,10 @@ def setup_postgres() -> None:
     """Install verson of postgresql we want for mac development with homebrew
     on catalina and later."""
 
-    print(f'{SCRIPT}: Ensuring postgres (usually 11) is installed and running')
+    print(f'{SCRIPT}: Ensuring postgres (usually 14) is installed and running')
     brewname = get_brewname()
     if not brewname:
-        brewname = POSTGRES11_FORMULA
+        brewname = POSTGRES_FORMULA
         install_postgres(brewname)
     else:
         # Sometimes postgresql gets unlinked if dev is tweaking their env

--- a/bin/mac-setup-postgres.sh
+++ b/bin/mac-setup-postgres.sh
@@ -12,24 +12,24 @@ SCRIPT=$(basename $0)
 # This script is only for comparison with python version
 echo "$SCRIPT: This script is deprecated: Try mac-setup-postgres.py"
 
-if brew ls postgresql@11 >/dev/null 2>&1 ; then
-  pg11_brewname="postgresql@11"
-elif brew ls postgresql --versions >/dev/null 2>&1 | grep "\s11\.\d" ; then
+if brew ls postgresql@14 >/dev/null 2>&1 ; then
+  pg_brewname="postgresql@14"
+elif brew ls postgresql --versions >/dev/null 2>&1 | grep "\s14\.\d" ; then
   # TODO(ericbrown): Why do we allow this?
-  pg11_brewname="postgresql"
+  pg_brewname="postgresql"
 else
   # We do not have pg11 installed
-  pg11_brewname="NONE"
+  pg_brewname="NONE"
 fi
 
 echo "$SCRIPT: Ensure postgres (usually 11) is installed and running"
 
-if [ "$pg11_brewname" = "NONE" ] ; then
-  pg11_brewname="postgresql@11"
-  echo "$SCRIPT: Installing ${pg11_brewname}"
-  brew install ${pg11_brewname}
+if [ "$pg_brewname" = "NONE" ] ; then
+  pg_brewname="postgresql@14"
+  echo "$SCRIPT: Installing ${pg_brewname}"
+  brew install ${pg_brewname}
   # swtich icu4c to 64.2
-  # if default verison is 63.x and v64.2 was installed by postgres@11
+  # if default verison is 63.x and v64.2 was installed by postgres@14
   if [ "$(brew ls icu4c --versions |grep "icu4c 63")" ] && [ "$(brew ls icu4c | grep 64.2 >/dev/null 2>&1)" ]; then
     # TODO(ericbrown): I don't think we ever get here. (brew switch is deprecated)
     brew switch icu4c 64.2
@@ -37,19 +37,19 @@ if [ "$pg11_brewname" = "NONE" ] ; then
 
   # Brew doesn't link non-latest versions on install. This command fixes that
   # allowing postgresql and commads like psql to be found
-  brew link --force --overwrite ${pg11_brewname}
+  brew link --force --overwrite ${pg_brewname}
 else
-  echo "$SCRIPT: ${pg11_brewname} already installed"
+  echo "$SCRIPT: ${pg_brewname} already installed"
 fi
 
 # Sometimes postgresql does not link (or gets unlinked for some reason)
-which psql || brew link ${pg11_brewname}
+which psql || brew link ${pg_brewname}
 
 # Make sure that postgres is started, so that we can create the user below,
 # if necessary and so later steps in setup_webapp can connect to the db.
-if ! brew services list | grep "$pg11_brewname" | grep -q started; then
+if ! brew services list | grep "$pg_brewname" | grep -q started; then
   echo "$SCRIPT: Starting postgreql service"
-  brew services start "$pg11_brewname" 2>&1
+  brew services start "$pg_brewname" 2>&1
   # Give postgres a chance to start up before we connect to it on the next line
   sleep 5
 else

--- a/bin/mac-update-postgres.sh
+++ b/bin/mac-update-postgres.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+brew install golang-migrate || echo "golang-migrate is already installed"
+
+if brew ls postgresql@14 >/dev/null 2>&1 ; then
+  echo "postgresql@14 already installed"
+else
+  # We do not have pg14 installed
+  brew install postgresql@14
+fi
+brew services stop postgresql@11 || echo "postgresql@11 not running"
+brew services start postgresql@14 || echo "postgresql@14 is already running"
+psql --quiet -c "CREATE ROLE postgres LOGIN SUPERUSER;" postgres;
+~/khan/webapp/services/progress-reports/create_databases.sh
+cd ~/khan/webapp/services/progress-reports/migrations/
+migrate -verbose -path .  -database 'postgres://postgres@localhost:5432/khan_dev?sslmode=disable' up

--- a/linux-functions.sh
+++ b/linux-functions.sh
@@ -250,20 +250,20 @@ install_watchman() {
 }
 
 install_postgresql() {
-    # postgresql-12 (not 11) is in normal repos for 20.04
-    # TODO(ericbrown): We do WANT postgresql-11 - INFRA-5679
+    # postgresql-14 (not 14) is in normal repos for 20.04
+    # TODO(ericbrown): We do WANT postgresql-14 - INFRA-5679
 
     #sudo apt-get remove postgresql-11 postgresql-13 postgresql-client-11 postgresql-client-12 postgresql-client-13
     #sudo apt-get remove postgresql-client-common postgresql-common
 
     # Instructions taken from
     # https://pgdash.io/blog/postgres-11-getting-started.html
-    # Postgres 11 is not available in 18.04, so we need to add the pg apt repository.
+    # Postgres 14 is not available in 18.04, so we need to add the pg apt repository.
     #curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
     #sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -c -s`-pgdg main"
     #sudo apt-get update
 
-    POSTGRESQL_VERSION=12
+    POSTGRESQL_VERSION=14
     echo "Installing postgresql-${POSTGRESQL_VERSION}"
     sudo apt-get install -y postgresql-${POSTGRESQL_VERSION} postgresql-contrib libpq-dev
 

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -310,13 +310,13 @@ install_postgresql() {
 
     sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -c -s`-pgdg main"
     sudo apt-get update
-    sudo apt-get install -y postgresql-11
+    sudo apt-get install -y postgresql-14
 
     # Set up authentication to allow connections from the postgres user with no
     # password. This matches the authentication setup that homebrew installs on
     # a mac. Unlike a mac, we do not need to create a postgres user manually.
-    sudo cp -av postgresql/pg_hba.conf "/etc/postgresql/11/main/pg_hba.conf"
-    sudo chown postgres.postgres "/etc/postgresql/11/main/pg_hba.conf"
+    sudo cp -av postgresql/pg_hba.conf "/etc/postgresql/14/main/pg_hba.conf"
+    sudo chown postgres.postgres "/etc/postgresql/14/main/pg_hba.conf"
     sudo service postgresql restart
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -325,7 +325,6 @@ install_hooks            # pre-req: clone_repos
 download_db_dump         # pre-req: install_deps
 create_pg_databases      # pre-req: install_deps
 
-
 echo
 echo "---------------------------------------------------------------------"
 


### PR DESCRIPTION
We have tested fairly extensively and found no real compatibility problems with upgrading from Postgresql 11 to 14, so we are updating this for local dev.

We are adding an update script to ease the transition for other developers.

Linux users should be able to self-service updating their own systems package managers.

Signed-off-by: Steve Coffman <steve@khanacademy.org>
