### PR TITLE
INFRA-8870 Simplify ssh passphrases in keychain

### DIFF
--- a/.bash_profile.khan
+++ b/.bash_profile.khan
@@ -45,3 +45,23 @@ fi
 if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
   alias brew86="arch -x86_64 /usr/local/bin/brew $@"
 fi
+
+# Add a mykeeper alias to run keeper with KA config
+alias mykeeper="keeper --config $HOME/.keeper-config.json"
+
+# Setting this allows us to store ssh-keys in the keychain without generating
+# a warning.  See ssh-add man page.
+export APPLE_SSH_ADD_BEHAVIOR=macos
+
+# Add ssh keys stored in the keychain to the ssh-agent
+# Note: IF you have an identity in ~/.ssh and DO NOT have a passphrase already
+#   in the keychain, you will be prompted for a passphrase.  This is because
+#   ssh-add will try to add the key to the agent, and will prompt for a
+#   passphrase if it doesn't have one in the keychain.
+#   If you have a passphrase in the keychain, you will not be prompted.
+#   If you don't have an identity in ~/.ssh, you will not be prompted.
+#   If you have an identity in ~/.ssh and DO have a passphrase in the keychain,
+#   you will not be prompted.
+#   (Being prompted should NOT happen if you ran ssh-add -K when you first
+#    created the key.)
+ssh-add -K

--- a/.zprofile.khan
+++ b/.zprofile.khan
@@ -8,6 +8,11 @@
 # The zsh shell does not load .profile itself, so we have to source
 # .profile here.
 
+# Add homebrew to path on M1 macs
+if [ `uname -m` = "arm64" ]; then
+    export PATH=/opt/homebrew/bin:$PATH
+fi
+
 if [ -z "$KA_DOTFILES_PROFILE_SOURCED" ]; then
    # We check and then set this environment variable to ensure that we source
    # .profile only once.  Depending on a user's dotfile configuration, it
@@ -41,3 +46,24 @@ if ! which gcloud >/dev/null; then
         source "$GCLOUD_COMPLETION_FILE"
     fi
 fi
+
+# Add a brew86 alias if we're on an ARM architecture Mac
+if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+  alias brew86="arch -x86_64 /usr/local/bin/brew $@"
+fi
+
+# Add a mykeeper alias to run keeper with KA config
+alias mykeeper="keeper --config $HOME/.keeper-config.json"
+
+# Add ssh keys stored in the keychain to the ssh-agent
+# Note: IF you have an identity in ~/.ssh and DO NOT have a passphrase already
+#   in the keychain, you will be prompted for a passphrase.  This is because
+#   ssh-add will try to add the key to the agent, and will prompt for a
+#   passphrase if it doesn't have one in the keychain.
+#   If you have a passphrase in the keychain, you will not be prompted.
+#   If you don't have an identity in ~/.ssh, you will not be prompted.
+#   If you have an identity in ~/.ssh and DO have a passphrase in the keychain,
+#   you will not be prompted.
+#   (Being prompted should NOT happen if you ran ssh-add -K when you first
+#    created the key.)
+ssh-add -K


### PR DESCRIPTION
Setting the environment variable APPLE_SSH_ADD_BEHAVIOR=macos removes unnecessary warnings when we run ssh-add -K. And running ssh-add -K slurps keys from the keychain into the ssh-agent for the user.

In recent months we've had several instances where DEVs have setup new machines and created new ssh keys with passphrases. Doing so makes khan dot-files flows fail. As a result, people have been falling back to creating ssh-keys without passphrases. While encrypted disks on OS X makes this less of a concern, it still allows a virus or other bad actor to steal credentails (a ssh private key without a passphrase) that could not be as easily stolen if the key had a passphrase stored in the keychain.

Issue: https://khanacademy.atlassian.net/browse/INFRA-8870

Test Plan:

1. Remove all private and public keys from ~/.ssh (for testing)
2. Remove any ssh passphrases from keychain (search for "ssh")
3. Remove all ssh keys from the ssh-agent i.e. ssh-add -D
4. Set environment variable APPLE_SSH_ADD_BEHAVIOR=macos
5. Create a new ssh key with a passphrase - i.e. ssh-keygen -t ecdsa
6. Add the new key to the keychain - i.e. ssh-add -K
7. Copy the created public key from ~/.ssh - i.e. ~/.ssh/id_ecdsa.pub
8. Add the public key to github - i.e. https://github.com/settings/keys
9. Start a new terminal window
10. Verify environment variable is set
11. Verify ssh-add -l lists your key
12. Go to /tmp and clone a repo that requires ssh auth - i.e. dotfiles