### PR TITLE
INFRA-8789 Fix github ssh-auth test

### DIFF
--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -117,11 +117,9 @@ verify_ssh_auth () {
     ssh_host="git@github.com"
     webpage_url="https://github.com/settings/ssh"
     instruction="Click 'Add SSH Key', paste into the box, and hit 'Add key'"
-
     info "Checking for GitHub ssh auth"
-    if ! ssh -T -v $ssh_host 2>&1 >/dev/null | grep \
-        -q -e "Authentication succeeded (publickey)"
-    then
+    # ssh returns 1 if auth succeeds, 255 if it fails (and 130 if passphrase is wrong)
+    if [ $(ssh -T $ssh_host >/dev/null; echo $?) -eq 1]; then
         if [ "$2" == "false" ]  # error if auth fails twice in a row
         then
             error "Still no luck with GitHub ssh auth. Ask a dev!"


### PR DESCRIPTION
Dotfiles was using the human readable output of ssh -T to check if ssh auth was working. This output is not consistent across versions of osx, so we now use the exit code of ssh -T to check if auth is working. (ssh returns 1 if auth succeeds, 255 if it fails (and 130 if passphrase is wrong).

I think we saw this problem before when upgrading to big sur (or some prior version of os x).

Issue: https://khanacademy.atlassian.net/browse/INFRA-8789

Test plan:

Run "make install"
Test it with no ssh keys installed and see if you get prompted to create one. Then run it with ssh keys installed and verify you do not get prompted.