### PR TITLE
[🔥AUDIT🔥] Switched info for echo in elevated mac script

### DIFF
--- a/mac-setup-elevated.sh
+++ b/mac-setup-elevated.sh
@@ -50,7 +50,7 @@ install_protoc() {
     # If the user has a homebrew version of protobuf installed, uninstall it so
     # we can manually install our own version in /usr/local.
     if brew list --formula | grep -q '^protobuf$'; then
-        info "Uninstalling homebrew version of protobuf\n"
+        echo "Uninstalling homebrew version of protobuf\n"
         brew uninstall protobuf
     fi
 

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -11,8 +11,8 @@ if [[ $(uname -m) = "arm64" ]]; then
     export PATH=/opt/homebrew/bin:$PATH
 fi
 
-# This will call down to brew UNLESS the machine is an ARM architecture 
-# Mac (ie M1), in which case this will use rosetta to interact with the x86 
+# This will call down to brew UNLESS the machine is an ARM architecture
+# Mac (ie M1), in which case this will use rosetta to interact with the x86
 # version of brew.
 brew86() {
     if [[ $(uname -m) = "arm64" ]]; then


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I ran into issues run the dotfiles because the dotfile needed to reinstall protobuf, which write a message to console using the `info` function.  The problem is that `info` function is not defined in the elevated script so that failed the rest of the dotfiles installation process.  I just switched out `info` for `echo` and called it a day.  Alternatively I could move all the print helper functions to the shared script but that didnt seem necessary.

Once that was fixed I was able to run dotfiles to completion which ultimately installed `fastly` which was the issue I was trying to fix in the first place.

Issue: "none"

## Test plan:
run `make` in the dotfile dir and verify it runs all the way to the end and installs `fastly`.