### PR TITLE
Add keeper cmd-line initialization

### DIFF
--- a/.bash_profile.khan
+++ b/.bash_profile.khan
@@ -45,3 +45,6 @@ fi
 if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
   alias brew86="arch -x86_64 /usr/local/bin/brew $@"
 fi
+
+# Add a mykeeper alias to run keeper with KA config
+alias mykeeper="keeper --config $HOME/.keeper-config.json"

--- a/.zprofile.khan
+++ b/.zprofile.khan
@@ -46,3 +46,11 @@ if ! which gcloud >/dev/null; then
         source "$GCLOUD_COMPLETION_FILE"
     fi
 fi
+
+# Add a brew86 alias if we're on an ARM architecture Mac
+if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+  alias brew86="arch -x86_64 /usr/local/bin/brew $@"
+fi
+
+# Add a mykeeper alias to run keeper with KA config
+alias mykeeper="keeper --config $HOME/.keeper-config.json"

--- a/bin/install-mac-mkcert.py
+++ b/bin/install-mac-mkcert.py
@@ -6,12 +6,19 @@ the other scripts that require elevated permissions (sudo) and because it
 requires a reboot after completion.
 """
 
+import os
 import subprocess
+
+# Ensure we are using the best "version" of brew
+BREW86_PREFIX = "/usr/local/bin/"
+BREW_PREFIX = "/opt/homebrew/bin/"
+BREW_PREFIX = BREW_PREFIX if os.path.isdir(BREW_PREFIX) else BREW86_PREFIX
+BREW = BREW_PREFIX + "brew"
 
 result = subprocess.run(['which', 'mkcert'], capture_output=True)
 if result.returncode != 0:
     # nss is a library that's required to make mkcert work with Firefox
-    subprocess.run(['brew', 'install', 'mkcert', 'nss'], check=True)
+    subprocess.run([BREW, 'install', 'mkcert', 'nss'], check=True)
     # The following will ask for your password
     subprocess.run(['mkcert', '-install'], check=True)
 

--- a/bin/mac-setup-keeper.sh
+++ b/bin/mac-setup-keeper.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+
+# Bail on any errors
+set -e
+
+# Install in $HOME by default, but can set an alternate destination via $1.
+ROOT=${1-$HOME}
+mkdir -p "$ROOT"
+
+# the directory all repositories will be cloned to
+REPOS_DIR="$ROOT/khan"
+
+# derived path location constants
+DEVTOOLS_DIR="$REPOS_DIR/devtools"
+KACLONE_BIN="$DEVTOOLS_DIR/ka-clone/bin/ka-clone"
+
+# Load shared setup functions.
+. "$DEVTOOLS_DIR"/khan-dotfiles/shared-functions.sh
+
+create_default_keeper_config
+
+# We want to run this only with the brew version of python, NOT OSX's python3
+install_keeper $(brew --prefix)/bin/python3
+
+echo "To test keeper is working, run the following:"
+echo "keeper --config \$HOME/.keeper-config.json list"

--- a/bin/mac-uninstall-brew.sh
+++ b/bin/mac-uninstall-brew.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+# This script is needed on rare occasions where devops wants to test khan-dotfiles
+# or where a DEV's environment needs a more complete reset.
+
+echo "This script needs your password to remove things as root."
+sudo sh -c 'echo Thanks'
+
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
+sudo rm -rf /opt/homebrew
+
+sudo arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
+sudo rm -rf /usr/local/Homebrew
+rm -rf ~/.virtualenv/khan27
+
+# Remove other things that may upgrade if user reinstalls
+sudo rm -rf ~/Library/Caches/pip
+sudo rm -rf ~/.npm
+sudo rm -rf ~/.yarnrc
+sudo rm -rf ~/go

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -250,15 +250,15 @@ install_node() {
 install_go() {
     if ! has_recent_go; then   # has_recent_go is from shared-functions.sh
         info "Installing go\n"
-        if brew86 ls go >/dev/null 2>&1; then
-            brew86 upgrade "go@$DESIRED_GO_VERSION"
+        if brew ls go >/dev/null 2>&1; then
+            brew upgrade "go@$DESIRED_GO_VERSION"
         else
-            brew86 install "go@$DESIRED_GO_VERSION"
+            brew install "go@$DESIRED_GO_VERSION"
         fi
 
         # Brew doesn't link non-latest versions of go on install. This command
         # fixes that, telling the system that this is the go executable to use
-        brew86 link --force --overwrite "go@$DESIRED_GO_VERSION"
+        brew link --force --overwrite "go@$DESIRED_GO_VERSION"
     else
         success "go already installed"
     fi

--- a/setup-gcloud.sh
+++ b/setup-gcloud.sh
@@ -95,7 +95,7 @@ gcloud components update --quiet --version="$version"
 #   communication
 # - beta: used for the command to start the pubsub emulator
 gcloud components install --quiet app-engine-java app-engine-python \
-    bq cloud-datastore-emulator gsutil pubsub-emulator beta
+    bq cloud-datastore-emulator gsutil pubsub-emulator beta kubectl
 
 # Turn off checking for updates automatically -- having gcloud always say
 # "you can update!" is not useful when we don't want you to!

--- a/setup.sh
+++ b/setup.sh
@@ -344,6 +344,10 @@ install_deps             # pre-reqs: clone_repos, install_and_setup_gcloud
 install_hooks            # pre-req: clone_repos
 download_db_dump         # pre-req: install_deps
 create_pg_databases      # pre-req: install_deps
+create_default_keeper_config # pre-req: update_userinfo
+
+# We want to run this only with the brew version of python, NOT OSX's python3
+install_keeper $(brew --prefix)/bin/python3
 
 echo
 echo "---------------------------------------------------------------------"

--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -187,6 +187,53 @@ create_and_activate_virtualenv() {
     fi
 }
 
+# Creates keeper config for command line access
+# This is interactive
+create_default_keeper_config() {
+    config_file=${HOME}/.keeper-config.json
+    if [ -e "${config_file}" ]; then
+        if [ "$(get_yn_input "Keeper config exists, do you want to recreate it now?" "n")" = "y" ]; then
+            rm -f ${config_file}
+        fi
+    fi
+
+    if [ ! -e "${config_file}" ]; then
+        gitemail=$(git config kaclone.email)
+        echo "Keeper Command Line setup"
+        echo "-------------------------"
+        echo "Khan Email: ${gitemail}"
+        echo "If this is incorrect, reenter it here."
+        read -p "Enter your KA email (or blank if ${gitemail} is correct): " email
+        email=${email:-$gitemail}
+
+        echo "If you haven't setup Keeper yet, you will not have a master password."
+        echo "Just hit <enter>. Once you setup Keeper, run mac-setup-keeper.sh."
+        read -s -p "Keeper Master Password: " master_password
+        echo
+        cat << EOF > ${config_file}
+{
+"server": "https://keepersecurity.com/api/v2/",
+"user": "${email}",
+"password": "${master_password}",
+"sso_master_password": true,
+"mfa_token": "",
+"mfa_type": "",
+"debug": false,
+"login_v3": false,
+"plugins": [],
+"commands": []
+}
+EOF
+    fi
+}
+
+# install keeper
+# $1: path to python3 (including python3 binary)
+install_keeper() {
+    python=$1
+    ${python} -m pip install keepercommander==16.5.18
+}
+
 # If we exit unexpectedly, log this warning.
 # Scripts should call "trap exit_warning EXIT" near the top to enable,
 # then "trap - EXIT" just before exiting on success.


### PR DESCRIPTION
Fix a number of things:
* Setup keeper command line
* Add a script to easily setup keeper command line later
* Add a script to delete homebrew (for testing and DEV debugging)
* Move golang to arm on M1s
* Ensure mkcert is installed for arm (not critical, but appropriate)
* Add brew86 alias to ksh
* Create "mykeeper" alias that uses correct config

Issue: None

Test plan:
- Ensure dotfile's "make" runs without issue
- Delete homebrew (by running mac-uninstall-brew.sh)
- Rerun dotfile's "make" to ensure all gets setup
- Run 'mac-setup-keeper.sh' and re-configure it
- Run 'mykeeper list' to ensure keeper command line is working