### PR TITLE
[🔥AUDIT🔥] Update the gcloud version to match the latest MAX_SUPPORTED_VERSION.

### DIFF
--- a/setup-gcloud.sh
+++ b/setup-gcloud.sh
@@ -53,7 +53,7 @@ PATH="$DEVTOOLS_DIR/google-cloud-sdk/bin:$PATH"
 
 echo "$SCRIPT: Using DEVTOOLS_DIR=${DEVTOOLS_DIR}"
 
-version=392.0.0  # should match webapp's MAX_SUPPORTED_VERSION
+version=419.0.0  # should match webapp's MAX_SUPPORTED_VERSION
 if ! which gcloud >/dev/null; then
     echo "$SCRIPT: Installing Google Cloud SDK (gcloud)"
     # On mac, we could alternately do `brew install google-cloud-sdk`,


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We updated the max-supported-version to 419.0.0 some time ago, but
forgot to update khan-dotfiles.  Well, better late than never!

Issue: https://khanacademy.slack.com/archives/C04SEFXQBNU/p1683131738105039

## Test plan:
None