### PR TITLE
Fix deciding which runner to invoke when checking for Homebrew on arm

### DIFF
--- a/bin/install-mac-homebrew.py
+++ b/bin/install-mac-homebrew.py
@@ -73,9 +73,9 @@ class HomebrewInstaller:
     def _validate_and_install_homebrew(self, force_x86=False):
         if platform.uname().machine == "arm64":
             if force_x86:
-                brew_runner = ["/opt/homebrew/bin/brew"]
-            else:
                 brew_runner = ["arch", "-x86_64", "/usr/local/bin/brew"]
+            else:
+                brew_runner = ["/opt/homebrew/bin/brew"]
         else:
             brew_runner = ["/usr/local/bin/brew"]
 


### PR DESCRIPTION
Our Homebrew install path tries to check if Homebrew x86 is already installed when running on an `arm` CPU. 

The check is inverted though and so we end up using the wrong "runner" to check if Homebrew is installed. This appears to only be an issue on a clean machine that doesn't have x86 Homebrew installed yet. After that the check is doing the wrong thing (checking for `arm` Homebrew when `force_x86` is `true` but succeeds anyways. 