### PR TITLE
Install python3.8 as part of khan-dotfiles.

### DIFF
--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -125,6 +125,12 @@ EOF
         updated_apt_repo=yes
     fi
 
+    # To get python3.8, later.
+    if ! ls /etc/apt/sources.list.d/ 2>&1 | grep -q deadsnakes; then
+        sudo add-apt-repository -y ppa:deadsnakes/ppa
+        updated_apt_repo=yes
+    fi
+
     # To get chrome, later.
     if [ ! -s /etc/apt/sources.list.d/google-chrome.list ]; then
         echo "deb http://dl.google.com/linux/chrome/deb/ stable main" \
@@ -134,12 +140,17 @@ EOF
         updated_apt_repo=yes
     fi
 
+
     # Register all that stuff we just did.
     if [ -n "$updated_apt_repo" ]; then
         sudo apt-get update -qq -y || true
     fi
 
-    # Python is needed for development. First try the Ubuntu 22.04+ packages, then
+    # Python3 is needed to run the python services (e.g. ai-guide-core).
+    # We pin it at python3.8 at the moment.
+    sudo apt-get install -y python3.8
+
+    # Python2 is needed for development. First try the Ubuntu 22.04+ packages, then
     # the Ubuntu <22.04 packages if that fails.
     sudo apt-get install -y python2-dev python-setuptools || sudo apt-get install -y python-dev python-mode python-setuptools
 
@@ -332,7 +343,7 @@ install_rust() {
 }
 
 install_fastly() {
-    builddir=$(mktemp -d -t fastly.XXXXX) 
+    builddir=$(mktemp -d -t fastly.XXXXX)
 
     (
         cd "$builddir"

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -347,6 +347,12 @@ install_jq() {
 }
 
 install_python_tools() {
+    # We need python3.8 for our python3 services (e.g. ai-guide-core)
+    if ! which python3.8 >/dev/null 2>&1; then
+        info "Installing python 3.8\n"
+        brew install python@3.8
+    fi
+
     # We use various python versions (e.g. internal-service)
     # and use Pyenv, pipenv as environment manager
     if ! brew ls pyenv >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary:
We need this to run python services such as ai-guide-core.  Not
everyone needs this -- not everyone develops on python, and if we use
local-musketeers then the container will already have python3.8 and
the user's local development environment won't need it -- but it's
safest to install it for everyone, and can't hurt anything.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9196

## Test plan:
I ran the new commands manually on my linux box, with success.  It's
fingers crossed for the os x changes.