### PR TITLE
Make sure we install docker, and set it up with gcloud.

### DIFF
--- a/linux-functions.sh
+++ b/linux-functions.sh
@@ -111,8 +111,9 @@ EOF
     #   services. We standardize on version 12 (the latest version suppported
     #   on appengine standard).
     # redis is needed to run memorystore on dev
+    # docker is needed to run dev-webapp containers
     # unzip is needed for other scripts
-    # tree sysdig docker iftop tcpflow are for diagnostics
+    # tree sysdig iftop tcpflow are for diagnostics
     # cargo is for rust / fastly
     # python-dev supplies Python.h for things built by setup.sh (but why?)
     # libncurses-dev is needed to build the readline we want
@@ -130,9 +131,10 @@ EOF
         libncurses-dev libreadline-dev \
         nodejs=12* \
         redis-server \
+        docker \
         curl \
         jq \
-        unzip tree sysdig docker iftop tcpflow \
+        unzip tree sysdig iftop tcpflow \
         cargo cargo-doc \
         python-dev \
         gcc \

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -385,6 +385,10 @@ install_fastly() {
 }
 
 install_docker() {
+    # TODO(csilvers): we should really be installing a docker UI here
+    # (docker desktop or docker rancher), which will install the
+    # docker CLI as part of it.  Once we decide on a UI we can replace
+    # these install instructions with the install for the UI instead.
     if ! which docker >/dev/null 2>&1; then
         update "Installing docker..."
         brew install --cask docker

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -384,6 +384,13 @@ install_fastly() {
     fi
 }
 
+install_docker() {
+    if ! which docker >/dev/null 2>&1; then
+        update "Installing docker..."
+        brew install docker
+    fi
+}
+
 echo
 success "Running Khan mac-setup-normal.sh\n"
 
@@ -409,5 +416,6 @@ install_helpful_tools
 install_watchman
 install_python_tools
 install_fastly
+install_docker
 
 trap - EXIT

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -387,7 +387,7 @@ install_fastly() {
 install_docker() {
     if ! which docker >/dev/null 2>&1; then
         update "Installing docker..."
-        brew install docker
+        brew install --cask docker
     fi
 }
 

--- a/setup-gcloud.sh
+++ b/setup-gcloud.sh
@@ -79,6 +79,7 @@ if [ -z "$(gcloud auth list --format='value(account)')" ]; then
     echo "$SCRIPT: Follow these instructions to authorize gcloud (twice)..."
     gcloud auth login ${GCLOUD_AUTH_ARGS}
     gcloud auth application-default login ${GCLOUD_AUTH_ARGS}
+    gcloud auth configure-docker us-central1-docker.pkg.dev
 fi
 
 echo "$SCRIPT: Ensuring gcloud is up to date and has the right components."


### PR DESCRIPTION
## Summary:
This is needed to run devserver locally in containers.

Note that this PR does not install docker-compose, or docker
desktop/docker ranch, or some other higher-level docker stuff that
devserver will need.  That will happen in a later PR.

Issue: https://khanacademy.slack.com/archives/C04LASC76G6/p1695236711905889

## Test plan:
Ran the gcloud command manually.  Will need help to test the mac command.