### PR TITLE
Remove mobile ios steps that are now done in mobile repo's setup.sh

### DIFF
--- a/bin/system_report.sh
+++ b/bin/system_report.sh
@@ -61,7 +61,7 @@ if [ "${uname_os}" = "Darwin" ]; then
     # Should be 10.15.x or 11.x
     osx_version=$(sw_vers -productVersion)
     kv "Version" "${osx_version}"
-    if echo "$osx_version" | grep -q -v -e '^12' -e '^11' ; then 
+    if echo "$osx_version" | grep -q -v -e '^12' -e '^11' ; then
         kv "!!! WARNING!!!" "Please update to OSX 12(Monterey)!!!"
 
     fi
@@ -72,7 +72,6 @@ header "Environment"
 kv "User" "$(whoami)"
 kv "Shell" "$SHELL"
 kv "PATH" "$PATH"
-
 
 # XCode, a big pain point on Mac
 if [ "${uname_os}" = "Darwin" ]; then

--- a/mac-ios-setup.sh
+++ b/mac-ios-setup.sh
@@ -44,15 +44,6 @@ install_xcodes() {
     fi
 }
 
-# Ensure Carthage is installed. Carthage is used to manage some dependencies and
-# is required to compile the app.
-install_carthage() {
-    if ! which carthage; then
-        update "Installing Carthage..."
-        brew install carthage
-    fi
-}
-
 install_fastlane() {
     update "Installing Fastlane and Cocoapods..."
     (cd "$REPOS_DIR/mobile/app/ios"; bundle install)
@@ -62,7 +53,6 @@ ensure_mac_os # Function defined in shared-functions.sh.
 # TODO(hannah): Ensure setup.sh has already been run.
 clone_mobile_repo
 install_xcodes
-install_carthage
 install_fastlane
 install_homebrew_libraries
 install_react_native_dependencies

--- a/mac-ios-setup.sh
+++ b/mac-ios-setup.sh
@@ -44,18 +44,19 @@ install_xcodes() {
     fi
 }
 
-install_fastlane() {
-    update "Installing Fastlane and Cocoapods..."
-    (cd "$REPOS_DIR/mobile/app/ios"; bundle install)
-}
-
 ensure_mac_os # Function defined in shared-functions.sh.
-# TODO(hannah): Ensure setup.sh has already been run.
 clone_mobile_repo
 install_xcodes
-install_fastlane
-install_homebrew_libraries
-install_react_native_dependencies
+
+# Most of the mobile development setup is delegated to a script in the mobile
+# repo. This keeps the code close to the dependencies and tools that use it and
+# makes it easier to maintain.
+if [ ! -f "$REPOS_DIR/mobile/setup.sh" ]; then
+    err_and_exit "ERROR: Could not find mobile repo's setup.sh script at: $REPOS_DIR/mobile/setup.sh\n" \
+                 "Please ask for help in #mobile on Slack."
+    exit 1
+fi
+"$REPOS_DIR/mobile/setup.sh"
 
 update "Done! Complete setup instructions at \
 https://khanacademy.atlassian.net/wiki/spaces/MG/pages/49284528/iOS+Environment+Setup"

--- a/mobile-functions.sh
+++ b/mobile-functions.sh
@@ -4,28 +4,10 @@ set -e -o pipefail
 
 # This file should be sourced from within a Bash-ish shell
 
-install_homebrew_libraries() {
-    update "Installing Homebrew dependencies..."
-    # The mobile project requires these Homebrew packages
-    brew install pkg-config cairo libpng jpeg giflib pango zopfli
-
-    if ! brew tap | grep "getsentry/tools";
-    then
-        brew tap getsentry/tools
-    fi
-
-    brew install getsentry/tools/sentry-cli
-}
-
 # Ensure the Mobile Github repo is cloned.
 clone_mobile_repo() {
     if [ ! -d "$REPOS_DIR/mobile" ]; then
         update "Cloning mobile repository..."
         kaclone_repo git@github.com:Khan/mobile "$REPOS_DIR/" --email="$gitmail"
     fi
-}
-
-install_react_native_dependencies() {
-    update "Installing react-native dependencies..."
-    (cd "$REPOS_DIR/mobile/app"; yarn)
 }


### PR DESCRIPTION
## Summary:

This is the first bits of moving mobile env setup to the mobile repo. Having these setup scripts in this repo makes it hard to maintain as the mobile tooling and dependencies change. Moving it into the mobile repo will hopefully make it easier to maintain and fix.

Issue: MOB-5221

## Test plan:

Run `./mac-ios-setup.sh` (if you don't have Khan/mobile#3249 checked out, it will error, otherwise it will run the setup in the mobile repo)