### PR TITLE
Update github signature in .ssh/known_hosts

### DIFF
--- a/mac-setup-elevated.sh
+++ b/mac-setup-elevated.sh
@@ -79,7 +79,7 @@ fi
 # Add github to known_hosts (one less prompt when QAing script)
 mkdir -p ~/.ssh
 grep -q github.com ~/.ssh/known_hosts 2>/dev/null || \
-    echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" \
+    echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=" \
         >> ~/.ssh/known_hosts
 
 "$DEVTOOLS_DIR"/khan-dotfiles/bin/install-mac-homebrew.py


### PR DESCRIPTION
## Summary:
GitHub updated their RSA SSH host key in March[1], but khan-dotfiles is still
installing the signature for the old, now invalid key. The old signature
results in this scary message being displayed when running khan-dotfiles on a
machine without any existing signatures:
```
[ .. ] Checking for GitHub ssh auth
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
Someone could be eavesdropping on you right now (man-in-the-middle attack)!
It is also possible that a host key has just been changed.
```

This PR updates the installed signature to match the new key.

Note: the signature was copied from my .ssh/known_hosts file.

[1] https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/

Issue: DEV-1090

## Test plan:
I deleted all other github.com entries from my .ssh/known_hosts and then ran:
```
ssh -T git@github.com
```
That output:
```
Hi dnerdy! You've successfully authenticated, but GitHub does not provide shell access.
```
which means the signature was accepted (because ssh connected without issue).