### PR TITLE
Install python 3.11 on developer machines.

### DIFF
--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -147,8 +147,10 @@ EOF
     fi
 
     # Python3 is needed to run the python services (e.g. ai-guide-core).
-    # We pin it at python3.8 at the moment.
+    # We pin it at python3.8 at the moment, but will move it to python3.11 soon
+    # TODO(csilvers, GL-1195): remove python3.8 ai-guide-core is on python3.11
     sudo apt-get install -y python3.8 python3.8-venv
+    sudo apt-get install -y python3.11 python3.11-venv
 
     # Python2 is needed for development. First try the Ubuntu 22.04+ packages, then
     # the Ubuntu <22.04 packages if that fails.

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -347,10 +347,16 @@ install_jq() {
 }
 
 install_python_tools() {
-    # We need python3.8 for our python3 services (e.g. ai-guide-core)
+    # Python3 is needed to run the python services (e.g. ai-guide-core).
+    # We pin it at python3.8 at the moment, but will move it to python3.11 soon
+    # TODO(csilvers, GL-1195): remove python3.8 ai-guide-core is on python3.11
     if ! which python3.8 >/dev/null 2>&1; then
         info "Installing python 3.8\n"
         brew install python@3.8
+    fi
+    if ! which python3.11 >/dev/null 2>&1; then
+        info "Installing python 3.11\n"
+        brew install python@3.11
     fi
 
     # We use various python versions (e.g. internal-service)


### PR DESCRIPTION
## Summary:
We don't use it anywhere yet, but when we update ai-guide-core to use
python3.11 -- which we will soon -- we'll be ready!

Note that installing python3.11 does not change any working behavior
of the developer machines; the new python is not on the path, and the
/usr/bin/python3 symlink does not change to point to python3.11.  The
only way to access it is to explicitly run something via
```
python3.11 <something>
```

Nothing does that at the moment, but when we update ai-guide-core its
Makefile rules will start doing exactly that!

Issue: GL-1195

## Test plan:
I ran the new linux-setup.sh commands manually.  Someone will
have to do the same with the os-x commands.