### PR TITLE
Use brew's python3 only if it exists.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -348,8 +348,14 @@ download_db_dump         # pre-req: install_deps
 create_pg_databases      # pre-req: install_deps
 create_default_keeper_config # pre-req: update_userinfo
 
-# We want to run this only with the brew version of python, NOT OSX's python3
-install_keeper $(brew --prefix)/bin/python3
+# If brew is installed, run this only with the brew version of python, NOT OSX's python3
+if [ -n "$(which brew)" ]; then
+    echo "installing with brew"
+    install_keeper $(brew --prefix)/bin/python3
+else
+    echo "installing with python3"
+    install_keeper python3
+fi
 
 echo
 echo "---------------------------------------------------------------------"

--- a/setup.sh
+++ b/setup.sh
@@ -349,12 +349,10 @@ create_pg_databases      # pre-req: install_deps
 create_default_keeper_config # pre-req: update_userinfo
 
 # If brew is installed, run this only with the brew version of python, NOT OSX's python3
-if [ -n "$(which brew)" ]; then
-    echo "installing with brew"
-    install_keeper $(brew --prefix)/bin/python3
+if which brew >/dev/null 2>&1; then
+   install_keeper $(brew --prefix)/bin/python3
 else
-    echo "installing with python3"
-    install_keeper python3
+   install_keeper python3
 fi
 
 echo


### PR DESCRIPTION
## Summary:
When installing Keeper, use `brew`'s version of Python3 if it is installed on the user's system.
Otherwise, just use `python3`. I assume users with Macs will use `brew`, and those with Linux
will use `python3`, so we could parhaps change the check to refer to the OS. However, it was
simple enough to just see if `brew` was installed.

Issue: none

## Test plan:
- Run `make` on my laptop where `brew` is not installed, ensure it does not try to use it.
- Change the check to something that IS installed (`bash` in my case), observe that it will try to use `brew` and fail.