### PR TITLE
Force homebrew formulas for icu4c 73.2

### DIFF
--- a/bin/mac-setup-postgres.py
+++ b/bin/mac-setup-postgres.py
@@ -71,10 +71,27 @@ def link_postgres_if_needed(brewname, force=False):
                        check=True, stdout=subprocess.DEVNULL)
 
 
-def install_postgres(brewname: str) -> None:
-    print(f'Installing {brewname}')
-    subprocess.run([BREW, 'install', brewname], check=True)
-    link_postgres_if_needed(brewname, force=True)
+def install_postgres() -> None:
+    # Install an older formula for postgres that is pinned to call icu4c 73.2 
+    # as that is the latest node@16 supports.
+    print('Downloading postgresql@14 with icu4c.rb 73.2 bindings')
+    subprocess.run(['wget', '-O', 'postgresql@14.rb', 'https://raw.githubusercontent.com/Homebrew/homebrew-core/521c3b3f579cd4df16e0b85b26a49e47d2daf9c6/Formula/p/postgresql@14.rb'], check=True)
+    print('Installing postgresql@14 with icu4c.rb 73.2 bindings')
+    subprocess.run(['BREW', 'install', 'postgresql@14.rb'], check=True)
+    link_postgres_if_needed('postgresql@14', force=True)
+    # Reinstall icu4c 73.2 as it will have got updated to 74.2+ during the 
+    # previous postgresql@14 install. Uninstall first to avoid
+    # reinstalling to avoid permissions errors trying to access files from one
+    # version that don't exist in the other.
+    print('Downloading icu4c.rb v73.2')
+    subprocess.run(['wget', '-O', 'icu4c.rb', 'https://raw.githubusercontent.com/Homebrew/homebrew-core/74261226614d00a324f31e2936b88e7b73519942/Formula/i/icu4c.rb'], check=True)
+    print('Reinstalling icu4c v73.2')
+    my_env = os.environ.copy()
+    # icu4c 73.2 formula wants to install latest postgres 14.11_1 but that wont
+    # work and makes a circular dependency on installing icu4c so we skip the
+    # check.
+    my_env["HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK"] = "1"
+    subprocess.run(['BREW', 'reinstall', 'icu4c.rb', '--force', '--skip-cask-deps'], check=True, env=my_env)
 
 
 def is_postgres_running(brewname: str) -> bool:
@@ -116,7 +133,7 @@ def setup_postgres() -> None:
     brewname = get_brewname()
     if not brewname:
         brewname = POSTGRES_FORMULA
-        install_postgres(brewname)
+        install_postgres()
     else:
         # Sometimes postgresql gets unlinked if dev is tweaking their env
         # Force in case user has another version of postgresql installed too

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -230,6 +230,17 @@ install_node() {
         # We need this because brew doesn't link /usr/local/bin/node
         # by default when installing non-latest node.
         brew link --force --overwrite node@16
+
+        # The latest node@16 formula is hard coded to call icu4c v73.2 but 
+        # homebrew always installs latest dependencies so we need to force the
+        # old icu4c v73.2 formula.
+        info "Downloading node@16 with bindings for icu4c v73.2."
+        wget -O icu4c.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/74261226614d00a324f31e2936b88e7b73519942/Formula/i/icu4c.rb
+        info "Installing node@16 with bindings for icu4c v73.2."
+        # icu4c 73.2 formula wants to install latest postgres 14.11_1 but that
+        # wont work and makes a circular dependency on installing icu4c so we
+        # skip the check.
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew reinstall icu4c.rb --force --skip-cask-deps
     fi
     # We don't want to force usage of node v16, but we want to make clear we
     # don't support anything else.


### PR DESCRIPTION
## Summary:
Since the node@16 formula is deprecated it will no
longer be updated to work with its latest
dependencies, namely icu4c. The latest is
currently icu4c 74.2 which breaks node@16 which it
is hard coded to look for. Force reinstall of
older icu4c 73.2 formula until we get off of
node@16.

https://github.com/Homebrew/homebrew-core/commit/a16dac3924fa87e5b96e2a1fc98d1fa4ee588c38

postgresql@14 was updated on February 22nd to a
hard coded dependency of icu4c 74.2 so also force
install of an older postgresql@14 formula that
has bindings for 73.2.

https://github.com/Homebrew/homebrew-core/commit/231ce1c9490463ad7b32ef3145a312ee1d6dc968

Issue: https://khanacademy.slack.com/archives/C04SEFXQBNU/p1709169846656299

Test plan:

1. brew services stop postgresql
2. brew uninstall postgresql@14
3. brew uninstall node@16
4. make
5. psql -tc "SELECT rolname from pg_catalog.pg_roles" postgres
6. node -v
7. (in webapp) make serve