### PR TITLE
Use the homebrew pip3, rather than the system pip3, if it exists.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -353,13 +353,7 @@ install_hooks            # pre-req: clone_repos
 download_db_dump         # pre-req: install_deps
 create_pg_databases      # pre-req: install_deps
 create_default_keeper_config # pre-req: update_userinfo
-
-# If brew is installed, run this only with the brew version of python, NOT OSX's python3
-if which brew >/dev/null 2>&1; then
-   install_keeper $(brew --prefix)/bin/python3
-else
-   install_keeper python3
-fi
+install_keeper python3
 
 echo
 echo "---------------------------------------------------------------------"

--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -224,7 +224,14 @@ create_and_activate_virtualenv() {
 # that (https://peps.python.org/pep-0668/), but we do it anyway.
 # $@: the arguments to `pip install`.
 pip3_install() {
-    pip3 install --break-system-packages "$@" >/dev/null 2>&1 || pip3 install "$@"
+    # If brew is installed, use its pip3 instead of the system pip3.
+    if which brew >/dev/null 2>&1 && [ -e "$(brew --prefix)/bin/pip3" ]; then
+        PIP3=$(brew --prefix)/bin/pip3
+    else
+        PIP3=pip3
+    fi
+    "$PIP3" install --break-system-packages "$@" >/dev/null 2>&1 \
+        || "$PIP3" install "$@"
 }
 
 # Creates keeper config for command line access


### PR DESCRIPTION
## Summary:
I saw that setup.sh wanted to use the homebrew python3 to install
keeper, and I lost that when I moved the keeper install to use pip3
instead of `python3 -m pip`.  This PR changes the functionality back
to how it was.

I don't know how much it matters, but it's probably a good practice to
use brew's python for everything.

Issue: none

## Test plan:
Fingers crossed.  I don't have a mac to test on.