### PR TITLE
Upgrade gcloud to the latest version.

### DIFF
--- a/setup-gcloud.sh
+++ b/setup-gcloud.sh
@@ -53,7 +53,7 @@ PATH="$DEVTOOLS_DIR/google-cloud-sdk/bin:$PATH"
 
 echo "$SCRIPT: Using DEVTOOLS_DIR=${DEVTOOLS_DIR}"
 
-version=419.0.0  # should match webapp's MAX_SUPPORTED_VERSION
+version=466.0.0  # should match webapp's MAX_SUPPORTED_VERSION
 if ! which gcloud >/dev/null; then
     echo "$SCRIPT: Installing Google Cloud SDK (gcloud)"
     # On mac, we could alternately do `brew install google-cloud-sdk`,


### PR DESCRIPTION
## Summary:
This version works with python3.12, whereas our current
max-gcloud-version barfs.  Python3.12 is installed by default on new
mac's.  This should get our new hires unblocked.

Issue: https://khanacademy.slack.com/archives/C04SEFXQBNU/p1709315735140919?thread_ts=1709156363.604639&cid=C04SEFXQBNU

## Test plan:
Fingers crossed!  I only have an old mac to test on.

Subscribers: @Theffy92, @jeffkhan