### PR TITLE
When running khan-dotfiles, always install the latest available gcloud.

### DIFF
--- a/setup-gcloud.sh
+++ b/setup-gcloud.sh
@@ -54,7 +54,8 @@ PATH="$DEVTOOLS_DIR/google-cloud-sdk/bin:$PATH"
 echo "$SCRIPT: Using DEVTOOLS_DIR=${DEVTOOLS_DIR}"
 
 version=466.0.0  # should match webapp's MAX_SUPPORTED_VERSION
-if ! which gcloud >/dev/null; then
+# This `if` fails if gcloud isn't installed, *or* if it's old.
+if ! gcloud version 2>&1 | fgrep -q "$version"; then
     echo "$SCRIPT: Installing Google Cloud SDK (gcloud)"
     # On mac, we could alternately do `brew install google-cloud-sdk`,
     # but we need this code for linux anyway, so we might as well be


### PR DESCRIPTION
## Summary:
This keeps everyone on a modern, tested version.  It also will help
people recover when gcloud starts failing due to library errors (as is
happening currently for folks who update to python3.12).

Issue: https://khanacademy.slack.com/archives/C04SEFXQBNU/p1709576047519769?thread_ts=1709428199.985889&cid=C04SEFXQBNU

## Test plan:
I ran the new command manually with success.