### PR TITLE
Check a new location for where java11 might be installed.

### DIFF
--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -112,7 +112,6 @@ install_mac_java() {
     if [ -d /opt/homebrew/opt/openjdk@11 ]; then
         brew_loc=/opt/homebrew/opt/openjdk@11
     elif [ -d /usr/local/Cellar/openjdk@11 ]; then
-        # Different versions are installed here, we'll take the latest
         brew_loc=/usr/local/Cellar/openjdk@11
     else
         error "Could not find the location of java 11, not installing it"
@@ -198,7 +197,7 @@ install_python2_virtualenv() {
 # Assumes pip and virtualenv are already installed.
 #
 # Arguments:
-#   $1: directory in which to put the virtualenv, typically ~/.virtualenv/khan27.
+#   $1: driectory in which to put the virtualenv, typically ~/.virtualenv/khan27.
 create_and_activate_virtualenv() {
     # On a arm64 mac, we MUST use the python2 version of virtualenv
     VIRTUALENV=$(which virtualenv)

--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -107,7 +107,8 @@ install_mac_java() {
 
     brew_install openjdk@11
 
-    # Symlink openjdk for the system Java wrappers.
+    # Symlink openjdk for the system Java wrappers.  This supports
+    # both M1 and x86_64 macs.
     if [ -d /opt/homebrew/opt/openjdk@11 ]; then
         brew_loc=/opt/homebrew/opt/openjdk@11
     elif [ -d /usr/local/Cellar/openjdk@11 ]; then

--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -113,10 +113,12 @@ install_mac_java() {
         brew_loc=/opt/homebrew/opt/openjdk@11
     elif [ -d /usr/local/Cellar/openjdk@11 ]; then
         # Different versions are installed here, we'll take the latest
-        brew_loc=$(ls -td /usr/local/Cellar/openjdk@11/11.* | head -n1)
+        brew_loc=/usr/local/Cellar/openjdk@11
     else
         error "Could not find the location of java 11, not installing it"
     fi
+    # Different versions are installed here, we'll take the latest.
+    brew_loc=$(ls -td "$brew_loc"/11.* | head -n1)
     sudo ln -sfn "$brew_loc"/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
 
     # Ensure JAVA_HOME is set in ~/.profile.khan

--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -107,13 +107,21 @@ install_mac_java() {
 
     brew_install openjdk@11
 
-    # Symlink openjdk for the system Java wrappers
-    sudo ln -sfn /opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
+    # Symlink openjdk for the system Java wrappers.
+    if [ -d /opt/homebrew/opt/openjdk@11 ]; then
+        brew_loc=/opt/homebrew/opt/openjdk@11
+    elif [ -d /usr/local/Cellar/openjdk@11 ]; then
+        # Different versions are installed here, we'll take the latest
+        brew_loc=$(ls -trd /usr/local/Cellar/openjdk@11/11.*)
+    else
+        error "Could not find the location of java 11, not installing it"
+    fi
+    sudo ln -sfn "$brew_loc"/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
 
     # Ensure JAVA_HOME is set in ~/.profile.khan
     # TODO (jwiesebron): Update other parts of dotfiles to use this convention
     add_to_dotfile 'export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-11.jdk'
-    add_to_dotfile 'export PATH="/opt/homebrew/opt/openjdk@11/bin:$PATH"'
+    add_to_dotfile 'export PATH="'"$brew_loc"/bin':$PATH"'
 }
 
 install_protoc_common() {

--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -112,7 +112,7 @@ install_mac_java() {
         brew_loc=/opt/homebrew/opt/openjdk@11
     elif [ -d /usr/local/Cellar/openjdk@11 ]; then
         # Different versions are installed here, we'll take the latest
-        brew_loc=$(ls -trd /usr/local/Cellar/openjdk@11/11.*)
+        brew_loc=$(ls -td /usr/local/Cellar/openjdk@11/11.* | head -n1)
     else
         error "Could not find the location of java 11, not installing it"
     fi


### PR DESCRIPTION
## Summary:
We were assuming it was in /opt/homebrew, but that's M1-specific.
Now we support x86_64 (/usr/local/Cellar) as well.

Issue: https://khanacademy.slack.com/archives/C04SEFXQBNU/p1709585608143269?thread_ts=1709428199.985889&cid=C04SEFXQBNU

## Test plan:
I ran the contents of `install_mac_java` on my mac, which had this
problem, and it then could run `java` without getting an error!