### PR TITLE
[🔥AUDIT🔥] Do not look in a subdir for java11 in the M1 case.

### DIFF
--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -112,12 +112,11 @@ install_mac_java() {
     if [ -d /opt/homebrew/opt/openjdk@11 ]; then
         brew_loc=/opt/homebrew/opt/openjdk@11
     elif [ -d /usr/local/Cellar/openjdk@11 ]; then
-        brew_loc=/usr/local/Cellar/openjdk@11
+        # Different versions are installed here, we'll take the latest.
+        brew_loc=$(ls -td /usr/local/Cellar/openjdk@11/11.* | head -n1)
     else
         error "Could not find the location of java 11, not installing it"
     fi
-    # Different versions are installed here, we'll take the latest.
-    brew_loc=$(ls -td "$brew_loc"/11.* | head -n1)
     sudo ln -sfn "$brew_loc"/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
 
     # Ensure JAVA_HOME is set in ~/.profile.khan


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
java lives in one of these directories:
```
/usr/local/Cellar/openjdk@11/11.<something>     # x86_64
/opt/homebrew/Cellar/openjdk@11/11.<something>  # M1
```

But M1 has a convenience symlink `/opt/homebrew/opt/openjdk@11`, which
points directly into `/opt/homebrew/Cellar/openjdk@11/11.<something>`.
I thought it pointed just to `/opt/homebrew/Cellar/openjdk@11`, but I
was wrong.  That means we shouldn't look for the `11.*` dir ourselves,
in the M1 case.

Issue: https://khanacademy.slack.com/archives/C04SEFXQBNU/p1709587347376909

## Test plan:
Fingers crossed, James is going to try it.