### PR TITLE
Install the `python` symlink on os x.

### DIFF
--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -295,6 +295,10 @@ install_python_tools() {
         info "Installing python 3.11\n"
         brew install python@3.11
     fi
+    # The python3 cask does not install `python` as a symlink, so we do.
+    if ! [ -e /usr/local/bin/python ]; then
+        ln -snf python3 /usr/local/bin/python
+    fi
 
     # We use various python versions (e.g. internal-service)
     # and use Pyenv, pipenv as environment manager


### PR DESCRIPTION
## Summary:
I thought that installing the python cask would do it.  Or maybe just
installing python3 via xcode.  But neither apparently does!  Let's do
it ourselves.

Issue: https://khanacademy.slack.com/archives/C04SEFXQBNU/p1710359878432319

## Test plan:
I ran this locally with success.