### PR TITLE
Update ka-clone to the latest master before using it if it already exists

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -167,8 +167,15 @@ clone_repo() {
 }
 
 clone_kaclone() {
-    echo "Installing ka-clone tool"
-    clone_repo git@github.com:Khan/ka-clone "$DEVTOOLS_DIR"
+    if [ -d "$DEVTOOLS_DIR/ka-clone" ]; then
+        echo "Updating ka-clone tool"
+        cd "$DEVTOOLS_DIR/ka-clone"
+        git checkout master
+        git pull
+    else
+        echo "Installing ka-clone tool"
+        clone_repo git@github.com:Khan/ka-clone "$DEVTOOLS_DIR"
+    fi
 }
 
 clone_webapp() {

--- a/setup.sh
+++ b/setup.sh
@@ -169,9 +169,8 @@ clone_repo() {
 clone_kaclone() {
     if [ -d "$DEVTOOLS_DIR/ka-clone" ]; then
         echo "Updating ka-clone tool"
-        cd "$DEVTOOLS_DIR/ka-clone"
-        git checkout master
-        git pull
+        git -C "$DEVTOOLS_DIR/ka-clone" checkout master
+        git -C "$DEVTOOLS_DIR/ka-clone" pull
     else
         echo "Installing ka-clone tool"
         clone_repo git@github.com:Khan/ka-clone "$DEVTOOLS_DIR"


### PR DESCRIPTION
Currently, `setup.sh` relies on `ka-clone` to clone our Khan repositories. The `ka-clone` repo is cloned _once_ when the script is run for the first time, but `git clone` won't do anything once the repo exists, so `ka-clone` may get out of date. I propose that we `git pull` the latest from `ka-clone` before using it to avoid this having to be a manual step, which it was for me. (See [Slack thread](https://khanacademy.slack.com/archives/C04SEFXQBNU/p1710359878432319))

The downside is if you are actively developing `ka-clone` and you didn't want it to pull for some reason. I avoided adding a `git checkout master` line in case a developer wanted to be working off another branch.