### PR TITLE
Don't do ssh-add in bash profile on Linux

### DIFF
--- a/.bash_profile.khan
+++ b/.bash_profile.khan
@@ -53,19 +53,22 @@ fi
 # Add a mykeeper alias to run keeper with KA config
 alias mykeeper="keeper --config $HOME/.keeper-config.json"
 
-# Setting this allows us to store ssh-keys in the keychain without generating
-# a warning.  See ssh-add man page.
-export APPLE_SSH_ADD_BEHAVIOR=macos
+if [ "$(uname -s)" = "Darwin" ]; then
+    # Setting this allows us to store ssh-keys in the keychain without generating
+    # a warning.  See ssh-add man page.
+    export APPLE_SSH_ADD_BEHAVIOR=macos
 
-# Add ssh keys stored in the keychain to the ssh-agent
-# Note: IF you have an identity in ~/.ssh and DO NOT have a passphrase already
-#   in the keychain, you will be prompted for a passphrase.  This is because
-#   ssh-add will try to add the key to the agent, and will prompt for a
-#   passphrase if it doesn't have one in the keychain.
-#   If you have a passphrase in the keychain, you will not be prompted.
-#   If you don't have an identity in ~/.ssh, you will not be prompted.
-#   If you have an identity in ~/.ssh and DO have a passphrase in the keychain,
-#   you will not be prompted.
-#   (Being prompted should NOT happen if you ran ssh-add -K when you first
-#    created the key.)
-ssh-add -K
+    # Add ssh keys stored in the keychain to the ssh-agent
+    # Note: IF you have an identity in ~/.ssh and DO NOT have a passphrase already
+    #   in the keychain, you will be prompted for a passphrase.  This is because
+    #   ssh-add will try to add the key to the agent, and will prompt for a
+    #   passphrase if it doesn't have one in the keychain.
+    #   If you have a passphrase in the keychain, you will not be prompted.
+    #   If you don't have an identity in ~/.ssh, you will not be prompted.
+    #   If you have an identity in ~/.ssh and DO have a passphrase in the keychain,
+    #   you will not be prompted.
+    #   (Being prompted should NOT happen if you ran ssh-add -K when you first
+    #    created the key.)
+    ssh-add -K
+fi
+


### PR DESCRIPTION
## Summary:
Previously, the bash profile would run `ssh-add -K` on all systems.
This caused a problem on Linux, because the `-K` option means
"Load resident keys from a FIDO authenticator" on non-MacOS versions
of OpenSSH. Since the bash profile is sourced by the bashrc file,
any new shell session on Linux prompts the user for an authenticator
PIN instead of showing a prompt.

This commit adds a guard to only run `ssh-add` on MacOS, so shell
sessions won't be blocked on Linux machines.

Issue: none

## Test plan:
- Open a terminal emulator on Linux and verify that a normal shell prompt appears.