### PR TITLE
Install node@20 on mac

### DIFF
--- a/bin/mac-setup-postgres.py
+++ b/bin/mac-setup-postgres.py
@@ -14,7 +14,6 @@
 # scripts.
 
 # TODO(ericbrown): Why do we support anything other than postgresql@14 ?
-# TODO(ericbrown): mac-setup.sh used to tweak icu4c - obsolete now?
 
 import os
 import re
@@ -72,24 +71,8 @@ def link_postgres_if_needed(brewname, force=False):
 
 
 def install_postgres() -> None:
-    # Install an older formula for postgres that is pinned to call icu4c 73.2 
-    # as that is the latest node@16 supports.
-    print('Downloading postgresql@14 with icu4c.rb 73.2 bindings')
-    subprocess.run(['wget', '-O', '/tmp/postgresql@14.rb', 'https://raw.githubusercontent.com/Homebrew/homebrew-core/521c3b3f579cd4df16e0b85b26a49e47d2daf9c6/Formula/p/postgresql@14.rb'], check=True)
-    print('Installing postgresql@14 with icu4c.rb 73.2 bindings')
-    subprocess.run(['BREW', 'install', '/tmp/postgresql@14.rb'], check=True)
+    subprocess.run(['BREW', 'install', 'postgresql@14'], check=True)
     link_postgres_if_needed('postgresql@14', force=True)
-    # Reinstall icu4c 73.2 as it will have got updated to 74.2+ during the 
-    # previous postgresql@14 install.
-    print('Downloading icu4c.rb v73.2')
-    subprocess.run(['wget', '-O', '/tmp/icu4c.rb', 'https://raw.githubusercontent.com/Homebrew/homebrew-core/74261226614d00a324f31e2936b88e7b73519942/Formula/i/icu4c.rb'], check=True)
-    print('Reinstalling icu4c v73.2')
-    my_env = os.environ.copy()
-    # icu4c 73.2 formula wants to install latest postgres 14.11_1 but that wont
-    # work and makes a circular dependency on installing icu4c so we skip the
-    # check.
-    my_env["HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK"] = "1"
-    subprocess.run(['BREW', 'reinstall', '/tmp/icu4c.rb', '--force', '--skip-cask-deps'], check=True, env=my_env)
 
 
 def is_postgres_running(brewname: str) -> bool:

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -155,37 +155,26 @@ update_git() {
 
 install_node() {
     if ! which node >/dev/null 2>&1; then
-        # Install node 16: It's LTS and the latest version supported on
+        # Install node 20: It's LTS and the latest version supported on
         # appengine standard.
-        brew install node@16
+        brew install node@20
 
         # We need this because brew doesn't link /usr/local/bin/node
         # by default when installing non-latest node.
-        brew link --force --overwrite node@16
-
-        # The latest node@16 formula is hard coded to call icu4c v73.2 but 
-        # homebrew always installs latest dependencies so we need to force the
-        # old icu4c v73.2 formula.
-        info "Downloading node@16 with bindings for icu4c v73.2."
-        wget -O /tmp/icu4c.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/74261226614d00a324f31e2936b88e7b73519942/Formula/i/icu4c.rb
-        info "Installing node@16 with bindings for icu4c v73.2."
-        # icu4c 73.2 formula wants to install latest postgres 14.11_1 but that
-        # wont work and makes a circular dependency on installing icu4c so we
-        # skip the check.
-        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew reinstall /tmp/icu4c.rb --force --skip-cask-deps
+        brew link --force --overwrite node@20
     fi
-    # We don't want to force usage of node v16, but we want to make clear we
+    # We don't want to force usage of node v20, but we want to make clear we
     # don't support anything else.
-    if ! node --version | grep "v16" >/dev/null ; then
-        notice "Your version of node is $(node --version). We currently only support v16."
-        if brew ls --versions node@16 >/dev/null ; then
-            notice "You do however have node 16 installed."
+    if ! node --version | grep "v20" >/dev/null ; then
+        notice "Your version of node is $(node --version). We currently only support v20."
+        if brew ls --versions node@20 >/dev/null ; then
+            notice "You do however have node 20 installed."
             notice "Consider running:"
         else
             notice "Consider running:"
-            notice "\t${tty_bold}brew install node@16${tty_normal}"
+            notice "\t${tty_bold}brew install node@20${tty_normal}"
         fi
-        notice "\t${tty_bold}brew link --force --overwrite node@16${tty_normal}"
+        notice "\t${tty_bold}brew link --force --overwrite node@20${tty_normal}"
         read -p "Press enter to continue..."
     fi
 }


### PR DESCRIPTION
## Summary:
The deprecated node@16 homebrew formula continues to cause user issues.
Install node@20 for mac users to avoid these broken dependencies.

Issue: none

Test plan:

Verify node@20 and postgresql@14 are installed correctly:

```sh
brew uninstall node@16
brew uninstall postgresql@14
make
psql -tc "SELECT rolname from pg_catalog.pg_roles" postgres
node -v
```

In webapp, verify local dev:

```sh
make deps
make serve
```