### PR TITLE
Uninstall node@16, upgrade node@20 and postgresql@14 on mac

### DIFF
--- a/bin/mac-setup-postgres.py
+++ b/bin/mac-setup-postgres.py
@@ -110,16 +110,15 @@ def setup_postgres() -> None:
         # The homebrew team only tests the latest versions of every package
         # together so make sure we're on latest.
         print(f'{SCRIPT}: {BREW} upgrade {brewname}')
-        result = subprocess.run([BREW, 'upgrade', POSTGRES_FORMULA],
-                                capture_output=True, check=True)
+        result = subprocess.check_output([BREW, 'upgrade', POSTGRES_FORMULA])
 
         # Initiate and wait for restart if an upgrade happened. Otherwise the
         # service won't be ready in time for does_postgres_user_exist().
         if (re.search(r'Upgrading \d+ outdated package',
-                      result.stdout.decode('utf-8'))):
+                      result.decode('utf-8'))):
             print(f'{SCRIPT}: {BREW} services restart {brewname}')
-            subprocess.run([BREW, 'services', 'restart', POSTGRES_FORMULA],
-                           check=True)
+            subprocess.check_call([BREW, 'services', 'restart',
+                                   POSTGRES_FORMULA])
 
         # Sometimes postgresql gets unlinked if dev is tweaking their env
         # Force in case user has another version of postgresql installed too

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -154,7 +154,7 @@ update_git() {
 
 # install_or_upgrade_brew_formula ensures the latest version of the passed
 # formula is installed as the homebrew team only tests the latest versions of
-# every package together.
+# every formula together.
 install_or_upgrade_brew_formula() {
     formulaName=$1
     
@@ -168,9 +168,9 @@ install_or_upgrade_brew_formula() {
 }
 
 install_node() {
-    # We need to uninstall the deprecated node@16 homebrew package if it is
+    # We need to uninstall the deprecated node@16 homebrew formula if it is
     # installed so its dependencies don't conflict with the dependencies of the
-    # latest postgresql@14 homebrew package.
+    # latest postgresql@14 homebrew formula.
     if brew ls --versions node@16 >/dev/null ; then
         brew uninstall node@16
     fi
@@ -316,7 +316,7 @@ install_python_tools() {
         info "Installing python 3.11\n"
         brew install python@3.11
     fi
-    # The python3 cask does not install `python` as a symlink, so we do.
+    # The python3 formula does not install `python` as a symlink, so we do.
     if ! [ -e /usr/local/bin/python ]; then
         ln -snf python3 /usr/local/bin/python
     fi

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -152,6 +152,21 @@ update_git() {
     fi
 }
 
+# install_or_upgrade_brew_formula ensures the latest version of the passed
+# formula is installed as the homebrew team only tests the latest versions of
+# every package together.
+install_or_upgrade_brew_formula() {
+    formulaName=$1
+    
+    if brew ls --versions "$formulaName" >/dev/null ; then
+        info "Upgrading brew formula $formulaName\n"
+        brew upgrade "$formulaName"
+    else
+        info "Installing brew formula $formulaName\n"
+        brew install "$formulaName"
+    fi
+}
+
 install_node() {
     # We need to uninstall the deprecated node@16 homebrew package if it is
     # installed so its dependencies don't conflict with the dependencies of the
@@ -160,25 +175,32 @@ install_node() {
         brew uninstall node@16
     fi
 
+    # Upgrade brew-installed node@20 if it is already installed.
+    if brew ls --versions node@20 >/dev/null ; then
+        install_or_upgrade_brew_formula node@20
+    fi
+
+    # Install node@20 homebrew formula if no node binary is found in $PATH.
     if ! which node >/dev/null 2>&1; then
         # Install node 20: It's LTS and the latest version supported on
         # appengine standard.
-        brew install node@20
+        install_or_upgrade_brew_formula node@20
 
         # We need this because brew doesn't link /opt/homebrew/bin/node
         # (/usr/local/bin/node on x86) by default when installing non-latest
         # node.
         brew link --force --overwrite node@20
     fi
+
+    # At this point, users should have a node binary, whether it's from homebrew
+    # (preferred), NVM or standard install.
+
     # We don't want to force usage of node v20, but we want to make clear we
     # don't support anything else.
     if ! node --version | grep "v20" >/dev/null ; then
         notice "Your version of node is $(node --version). We currently only support v20."
         if brew ls --versions node@20 >/dev/null ; then
-            # The homebrew team only tests the latest versions of every package
-            # together so make sure we're on latest.
-            brew upgrade node@20
-            notice "You do however have node 20 installed."
+            notice "You do however have node 20 installed via brew."
             notice "Consider running:"
         else
             notice "Consider running:"


### PR DESCRIPTION
## Summary:
The presence of the node@16 homebrew formula has undesirable effects
when installing postgresql@14 due to a mismatch in shared dependencies.
By removing node@16 before installing node@20 and postgresql@14,
homebrew is free to update all dependencies to latest.

Some users already have a functional node@20 brew install but are on an
older non-functional postgresql@14 due to us previously forcing
compatibility with the deprecated node@16. Fully embrace the fact that
the homebrew team only ever tests the latest formula against all other
latest formulas and upgrade node@20 and postgresql@14 if they're out of
date.

Issue: none

Test plan:

Replicate node@16 state:

```sh
brew uninstall node@16
brew uninstall node@20
brew uninstall postgresql@14

brew install node@16
brew link --force --overwrite node@16

wget -O /tmp/icu4c.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/74261226614d00a324f31e2936b88e7b73519942/Formula/i/icu4c.rb
HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew reinstall /tmp/icu4c.rb --force --skip-cask-deps

wget -O /tmp/postgresql@14.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/521c3b3f579cd4df16e0b85b26a49e47d2daf9c6/Formula/p/postgresql@14.rb
brew install /tmp/postgresql@14.rb
HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew reinstall /tmp/icu4c.rb --force --skip-cask-deps
```

Test node@16 setup:

```sh
brew ls --version postgresql@14
psql -tc "SELECT rolname from pg_catalog.pg_roles" postgres
node -v
```

Test khan-dotfiles upgrade to node@20 and latest postgresql@14:

```sh
make

psql -tc "SELECT rolname from pg_catalog.pg_roles" postgres
node -v
```

In webapp, verify local dev:

```sh
make deps
make serve
```