### PR TITLE
update-os-output-mac

### DIFF
--- a/mac-setup.sh
+++ b/mac-setup.sh
@@ -51,7 +51,7 @@ echo
 echo "Running Khan Installation Script 1.2"
 
 if ! sw_vers -productVersion 2>/dev/null | grep -q '10\.1[12345]\.' ; then
-    echo "This is tested on macOS 13 (Ventura)."
+    echo "This is tested on macOS 14 (Sonoma)."
     echo
     echo "If you find that this works on a newer version of macOS, "
     echo "please update this message."


### PR DESCRIPTION
Updates `mac-setup.sh` script print statement to output `This is tested on macOS 14 (Sonoma).` now that this script has executed successfully 3 times on computers running macOS 14 and using M3 chips.

The script was able to run locally after the `echo` was updated.