### PR TITLE
Copy ecdsa key to clipboard in SSH key setup step

### DIFF
--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -47,15 +47,15 @@ update_path() {
 }
 
 copy_ssh_key () {
-  if [ -e ~/.ssh/id_rsa ]
+  if [ -e ~/.ssh/id_ecdsa ]
+  then
+    pbcopy < ~/.ssh/id_ecdsa.pub
+  elif [ -e ~/.ssh/id_rsa ]
   then
     pbcopy < ~/.ssh/id_rsa.pub
   elif [ -e ~/.ssh/id_dsa ]
   then
     pbcopy < ~/.ssh/id_dsa.pub
-  elif [ -e ~/.ssh/id_ecdsa ]
-  then
-    pbcopy < ~/.ssh/id_ecdsa.pub
   else
     error "no ssh public keys found"
     exit
@@ -160,7 +160,7 @@ update_git() {
 # every formula together.
 install_or_upgrade_brew_formula() {
     formulaName=$1
-    
+
     if brew ls --versions "$formulaName" >/dev/null ; then
         info "Upgrading brew formula $formulaName\n"
         brew upgrade "$formulaName"

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -53,6 +53,9 @@ copy_ssh_key () {
   elif [ -e ~/.ssh/id_dsa ]
   then
     pbcopy < ~/.ssh/id_dsa.pub
+  elif [ -e ~/.ssh/id_ecdsa ]
+  then 
+    pbcopy < ~/.ssh/id_ecdsa.pub 
   else
     error "no ssh public keys found"
     exit

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -54,8 +54,8 @@ copy_ssh_key () {
   then
     pbcopy < ~/.ssh/id_dsa.pub
   elif [ -e ~/.ssh/id_ecdsa ]
-  then 
-    pbcopy < ~/.ssh/id_ecdsa.pub 
+  then
+    pbcopy < ~/.ssh/id_ecdsa.pub
   else
     error "no ssh public keys found"
     exit


### PR DESCRIPTION
## Summary 

When creating an SSH key for GitHub, the setup scripts runs `ssh-keygen` to create an `id_ecdsa` key (and there's a comment suggesting that previous versions used to generate an `id_rsa` key).

But the `copy_ssh_key` helper only checked for an `id_rsa` or `id_dsa` file, so it would crash when reaching that point.

This adds support for copying the `id_ecdsa` to the clipboard in the  `copy_ssh_key` helper.

## Test plan

- Delete or temporarily move your keys in `~/.ssh`
- Run the script
