### PR TITLE
Update the build command for OLC

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -317,7 +317,7 @@ install_hooks() {
 
 install_our_lovely_cli() {
   cd "$DEVTOOLS_DIR/our-lovely-cli"
-  npm install
+  make
 }
 
 check_dependencies


### PR DESCRIPTION
## Summary

The build command in `install_our_lovely_cli()` is not quite right because:
- OLC has a Makefile that includes other additional build steps in addition to installing node modules dependencies.
- OLC uses `yarn` so doing `npm install` causes a warning about a `package-lock.json` created by a different package manager when doing subsequent runs of `yarn`

## Test plan

- Run script