### PR TITLE
fix: add www.khanacademy.dev to hosts file; remove wildcard

### DIFF
--- a/bin/edit-system-config.sh
+++ b/bin/edit-system-config.sh
@@ -45,6 +45,6 @@ fi
 
 if ! grep -q khanacademy.dev /etc/hosts; then
     echo "Adding khanacademy.dev to /etc/hosts"
-    echo "127.0.0.1 storage.khanacademy.dev khanacademy.dev *.khanacademy.dev" | \
+    echo "127.0.0.1 storage.khanacademy.dev khanacademy.dev www.khanacademy.dev" | \
         sudo tee -a /etc/hosts
 fi


### PR DESCRIPTION
wildcards aren't allowed in hosts file, so just removing that. added `www.khanacademy.dev` because I saw a case where the dev-server was redirecting to it. I'm sure there are more of these we'd need/want to add as well.

Ref: https://www.man7.org/linux/man-pages/man5/hosts.5.html
