### PR TITLE
Forgot to add an alias to .gitconfig.khan needed by other aliases

### DIFF
--- a/.gitconfig.khan
+++ b/.gitconfig.khan
@@ -35,6 +35,7 @@
   outgoing = "!git fetch >/dev/null 2>&1; git log @{upstream}..HEAD"
   incoming = "!git fetch >/dev/null 2>&1; git log HEAD..@{upstream}"
   update-submodule = !bash -c 'git pull --no-rebase && pushd $1 && git co master && git pull && popd && git commit ${1%/} -m Substate\\ for\\ ${1%/} -m Test\\ plan: -m None && git push' --
+  branch-name = "!git rev-parse --abbrev-ref HEAD"
   pup = "!git push origin $(git branch-name)"
   pown = "!git pull origin $(git branch-name)"
   pupl = pup --force-with-lease


### PR DESCRIPTION
## Summary:
My previously-added aliases reference the one I just added, but since I had it configred elsewhere in gitconfig scope, I didn't notice it was missing.

Issue: XXX-XXXX

## Test plan:
Unset the alias, then let the include to this .gitconfig file bring it back in. See that you can push the branch. Use `git config --list --show-origin --show-scope` to confirm things.