### PR TITLE
Don't include the commit template twice

### DIFF
--- a/.gitconfig.khan
+++ b/.gitconfig.khan
@@ -66,8 +66,5 @@
   ls-ignored = ls-files --exclude-standard --ignored --others
   conflicts = diff --name-only --diff-filter=U
 
-[commit]
-  template = ~/.git_template/commit_template
-
 [push]
   default = simple


### PR DESCRIPTION
## Summary:
If someone tells `ka-clone` that they don't want the commit template, they get stuck with it anyway, because it's also in this config file. So I removed it.

Issue: XXX-XXXX

## Test plan:
- Run `ka-clone --repair --no-msg` on a clean repo and then `git config --show-scope --show-origin --get-all commit.template` and see that it isn't getting included by `~/.gitconfig-khan`