### PR TITLE
Install pnpm as part of the dotfiles setup.

### DIFF
--- a/bin/mac-uninstall-brew.sh
+++ b/bin/mac-uninstall-brew.sh
@@ -47,5 +47,10 @@ echo "Removing other things that may upgrade if user reinstalls..."
 sudo rm -rf ~/Library/Caches/pip
 sudo rm -rf ~/.npm
 sudo rm -rf ~/.yarnrc
+# NOTE(john): We could delete the pnpm store, however pnpm's store isn't
+# just a cache, it's all the packages installed by pnpm. It symlinks to
+# the global store, so deleting it would require reinstalling all the
+# packages. If we do want to delete it, I think this would work:
+# sudo rm -rf "$(pnpm store path)"
 sudo rm -rf ~/go
 echo "Done"

--- a/bin/system_report.sh
+++ b/bin/system_report.sh
@@ -104,6 +104,7 @@ header "Node/JS"
 tool_version node --version
 tool_version npm --version
 tool_version yarn --version
+tool_version pnpm --version
 
 header "Go"
 tool_version go version

--- a/containers/kabuild/Dockerfile
+++ b/containers/kabuild/Dockerfile
@@ -80,6 +80,9 @@ RUN apt-get install -y \
 
 RUN pip3 install -q pipenv
 RUN npm install -g yarn
+# Install pnpm, following:
+# https://pnpm.io/installation
+RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash -
 
 # protoc
 RUN mkdir -p /tmp/protoc

--- a/setup.sh
+++ b/setup.sh
@@ -252,6 +252,14 @@ install_deps() {
             sudo npm install -g yarn
         fi
     fi
+
+    # Need to install pnpm first before run `make install_deps`
+    # in webapp.
+    echo "Installing pnpm"
+    if ! which pnpm >/dev/null 2>&1; then
+        curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=10.0.0 sh -
+    fi
+
     # By default, third party Go tools are install to this directory
     mkdir -p "$ROOT"/go/bin
 


### PR DESCRIPTION
## Summary:
This will make it so that folks will have pnpm already installed on their dev machine for when they need to use it.

Issue: FEI-6144

## Test plan:

I made sure I didn't have pnpm already installed.

I ran `./setup.sh` and it successfully installed pnpm.

Running `pnpm -v` gave me `10.0.0`.