### PR TITLE
[FEI-6144.3] More PNPM install tweaks.

### DIFF
--- a/bin/mac-uninstall-brew.sh
+++ b/bin/mac-uninstall-brew.sh
@@ -47,10 +47,6 @@ echo "Removing other things that may upgrade if user reinstalls..."
 sudo rm -rf ~/Library/Caches/pip
 sudo rm -rf ~/.npm
 sudo rm -rf ~/.yarnrc
-# NOTE(john): We could delete the pnpm store, however pnpm's store isn't
-# just a cache, it's all the packages installed by pnpm. It symlinks to
-# the global store, so deleting it would require reinstalling all the
-# packages. If we do want to delete it, I think this would work:
-# sudo rm -rf "$(pnpm store path)"
+pnpm store prune
 sudo rm -rf ~/go
 echo "Done"

--- a/containers/kabuild/Dockerfile
+++ b/containers/kabuild/Dockerfile
@@ -81,8 +81,8 @@ RUN apt-get install -y \
 RUN pip3 install -q pipenv
 RUN npm install -g yarn
 # Install pnpm, following:
-# https://pnpm.io/installation
-RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash -
+# https://pnpm.io/installation#using-corepack
+RUN corepack enable pnpm
 
 # protoc
 RUN mkdir -p /tmp/protoc

--- a/setup.sh
+++ b/setup.sh
@@ -258,6 +258,11 @@ install_deps() {
     # Following: https://pnpm.io/installation#using-corepack
     echo "Installing pnpm"
     if ! which pnpm >/dev/null 2>&1; then
+        if [[ -n "${IS_MAC}" ]]; then
+            if ! which corepack >/dev/null 2>&1; then
+                brew install corepack
+            fi
+        fi
         corepack enable pnpm
     fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -255,9 +255,10 @@ install_deps() {
 
     # Need to install pnpm first before run `make install_deps`
     # in webapp.
+    # Following: https://pnpm.io/installation#using-corepack
     echo "Installing pnpm"
     if ! which pnpm >/dev/null 2>&1; then
-        curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=10.0.0 sh -
+        corepack enable pnpm
     fi
 
     # By default, third party Go tools are install to this directory

--- a/setup.sh
+++ b/setup.sh
@@ -258,7 +258,7 @@ install_deps() {
     # Following: https://pnpm.io/installation#using-corepack
     echo "Installing pnpm"
     if ! which pnpm >/dev/null 2>&1; then
-        if [[ -n "${IS_MAC}" ]]; then
+        if [ -n "${IS_MAC}" ]; then
             if ! which corepack >/dev/null 2>&1; then
                 brew install corepack
             fi


### PR DESCRIPTION
## Summary:
Did some more reading, turns out running `pnpm store prune` is safe to do!

Also, I think we're going to want to manage pnpm installations using corepack (which is bundled with Node since v16). It makes it very easy for people to get started.

Issue: FEI-6144

## Test plan:
I ran the commands locally and they worked fine!