### PR TITLE
Install the latest version of protoc.

### DIFF
--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -245,7 +245,7 @@ EOF
 install_protoc() {
     # The linux and mac installation process is the same aside from the
     # platform-dependent zip archive.
-    install_protoc_common https://github.com/google/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip
+    install_protoc_common linux x86_64
 }
 
 install_watchman() {

--- a/mac-setup-elevated.sh
+++ b/mac-setup-elevated.sh
@@ -58,7 +58,7 @@ install_protoc() {
 
     # The mac and linux installation process is the same from here on out aside
     # from the platform-dependent zip archive.
-    install_protoc_common https://github.com/protocolbuffers/protobuf/releases/download/v3.4.0/protoc-3.4.0-osx-x86_64.zip
+    install_protoc_common osx x86_64
 }
 
 # TODO(ericbrown): Detect pre-requisites (i.e. brew, etc.)

--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -198,12 +198,12 @@ install_protoc_common() {
             # permissions as needed.
             sudo install -m755 ./bin/protoc /usr/local/bin/protoc-${PROTOC_VERSION}
             # This probably isn't necessary, but just to be safe.
-            sudo rm -rf /usr/local/include/google/protobuf-${PROTOC_VERSION}
-            sudo mkdir -p /usr/local/include/google
+            sudo rm -rf /usr/local/include/protobuf-${PROTOC_VERSION}
+            sudo mkdir -p /usr/local/include/protobuf-${PROTOC_VERSION}/google
             # Move the protoc include files to the final location and set the
             # permissions as needed.
-            sudo mv ./include/google/protobuf /usr/local/include/google/protobuf-${PROTOC_VERSION}
-            sudo chmod -R a+rX /usr/local/include/google/protobuf-${PROTOC_VERSION}
+            sudo mv ./include/google/protobuf /usr/local/include/protobuf-${PROTOC_VERSION}/google/
+            sudo chmod -R a+rX /usr/local/include/protobuf-${PROTOC_VERSION}
         )
         rm -rf /tmp/protoc
     else

--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -171,7 +171,7 @@ install_protoc_common() {
     # Platform independent installation of protoc.
     # usage: install_protoc_common <os> <arch>
     # os: `linux` or `osx`
-    # arch: `x86_86` or `aarch` or `universal_binary` (for osx only)
+    # arch: `x86_64` or `aarch` or `universal_binary` (for osx only)
 
     # The URL of the protoc zip file is passed as the first argument to this
     # function. This file is platform dependent.


### PR DESCRIPTION
## Summary:
In Khan/webapp#29166, I updated the protoc libraries -- the things that
emit compiled protobufs in different languages -- to the latest
version.  Now it's time to update the protoc compiler itself.  This is
harder because, sadly, the compiler isn't packaged, and isn't a go
module.  Instead, it's a binary that you have to install.  We do that
in khan-dotfiles.  This PR changes khan-dotfiles to install the latest
version.

To make the transition easier -- and to make future updates to protoc
easier -- I now version the binary and the include directory.  So
running this won't break any current webapp branches.  And when it's
time to update webapp to use the new protoc, I just need to point it
to the new binary name (and new include folders) and things will work.

I will be making a similar change to Khan/aws-config to change how
protoc is installed on jenkins.  I will also be changing the github
action in Khan/webapp (in https://github.com/Khan/webapp/pull/29407).

Issue: none

## Test plan:
I ran this manually, and then did:
```
% protoc --version
libprotoc 3.4.0
% protoc-29.3 --version
libprotoc 29.3
```