### PR TITLE
No longer install the protobuf compiler as part of khan-dotfiles setup.

### DIFF
--- a/bin/system_report.sh
+++ b/bin/system_report.sh
@@ -124,7 +124,6 @@ tool_version psql --version
 header "Java"
 tool_version java -version
 
-# TODO(dbraley): (A) check protoc
 # TODO(dbraley): (A) check watchman
 # TODO(dbraley): (A) check mac apps
 

--- a/containers/kabuild/Dockerfile
+++ b/containers/kabuild/Dockerfile
@@ -84,19 +84,6 @@ RUN npm install -g yarn
 # https://pnpm.io/installation#using-corepack
 RUN corepack enable pnpm
 
-# protoc
-RUN mkdir -p /tmp/protoc
-RUN wget -O /tmp/protoc/protoc-3.4.0.zip https://github.com/google/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip
-WORKDIR /tmp/protoc
-RUN unzip -q protoc-3.4.0.zip
-RUN install -m755 ./bin/protoc /usr/local/bin
-RUN rm -rf /usr/local/include/google/protobuf
-RUN mkdir -p /usr/local/include/google
-RUN mv ./include/google/protobuf /usr/local/include/google/
-RUN chmod -R a+rX /usr/local/include/google/protobuf
-WORKDIR /root
-RUN rm -rf /tmp/protoc
-
 WORKDIR /root
 
 ENV GROUP_NAME=khandev

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -242,12 +242,6 @@ EOF
     install_mkcert
 }
 
-install_protoc() {
-    # The linux and mac installation process is the same aside from the
-    # platform-dependent zip archive.
-    install_protoc_common https://github.com/google/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip
-}
-
 install_watchman() {
     if ! which watchman ; then
         update "Installing watchman..."
@@ -352,7 +346,6 @@ echo "This setup script needs your password to install things as root."
 sudo sh -c 'echo Thanks'
 
 install_packages
-install_protoc
 install_watchman
 setup_clock
 config_inotify

--- a/mac-setup-elevated.sh
+++ b/mac-setup-elevated.sh
@@ -46,21 +46,6 @@ DEVTOOLS_DIR="$REPOS_DIR/devtools"
 # Load shared setup functions.
 . "$DEVTOOLS_DIR"/khan-dotfiles/shared-functions.sh
 
-install_protoc() {
-    # If the user has a homebrew version of protobuf installed, uninstall it so
-    # we can manually install our own version in /usr/local.
-    if brew list --formula | grep -q '^protobuf$'; then
-        echo "Uninstalling homebrew version of protobuf\n"
-        brew uninstall protobuf
-    fi
-
-    brew install -q wget
-
-    # The mac and linux installation process is the same from here on out aside
-    # from the platform-dependent zip archive.
-    install_protoc_common https://github.com/protocolbuffers/protobuf/releases/download/v3.4.0/protoc-3.4.0-osx-x86_64.zip
-}
-
 # TODO(ericbrown): Detect pre-requisites (i.e. brew, etc.)
 
 # Run sudo once at the beginning to get the necessary permissions.
@@ -86,8 +71,6 @@ fi
 
 # It used to be we needed to install xcode-tools, now homebrew does this for us
 #"$DEVTOOLS_DIR"/khan-dotfiles/bin/install-mac-gcc.sh
-
-install_protoc
 
 # We use java for our google cloud dataflow jobs that live in webapp
 # (as well as in khan-linter for linting those jobs)

--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -157,48 +157,6 @@ install_mac_java() {
     add_to_dotfile 'export PATH="'"$brew_loc"/bin':$PATH"'
 }
 
-install_protoc_common() {
-    # Platform independent installation of protoc.
-    # usage: install_protoc_common <zip_url>
-
-    # The URL of the protoc zip file is passed as the first argument to this
-    # function. This file is platform dependent.
-    zip_url=$1
-
-    # We use protocol buffers in webapp's event log stream infrastructure. This
-    # installs the protocol buffer compiler (which generates go & java code
-    # from the protocol buffer definitions), as well as a go-based compiler
-    # plugin that allows us to generate bigquery schemas as well.
-
-    if ! which protoc >/dev/null || ! protoc --version | grep -q 3.4.0; then
-        echo "Installing protoc"
-        mkdir -p /tmp/protoc
-        wget -O /tmp/protoc/protoc-3.4.0.zip "$zip_url"
-        # Change directories within a subshell so that we don't have to worry
-        # about changing back to the current directory when done.
-        (
-            cd /tmp/protoc
-            # This puts the compiler itself into ./bin/protoc and several
-            # definitions into ./include/google/protobuf we move them both
-            # into /usr/local.
-            unzip -q protoc-3.4.0.zip
-            # Move the protoc binary to the final location and set the
-            # permissions as needed.
-            sudo install -m755 ./bin/protoc /usr/local/bin
-            # Remove old versions of the includes, if they exist
-            sudo rm -rf /usr/local/include/google/protobuf
-            sudo mkdir -p /usr/local/include/google
-            # Move the protoc include files to the final location and set the
-            # permissions as needed.
-            sudo mv ./include/google/protobuf /usr/local/include/google/
-            sudo chmod -R a+rX /usr/local/include/google/protobuf
-        )
-        rm -rf /tmp/protoc
-    else
-        echo "protoc already installed"
-    fi
-}
-
 DESIRED_GO_MAJOR_VERISON=1
 DESIRED_GO_MINOR_VERISON=22
 DESIRED_GO_VERSION="$DESIRED_GO_MAJOR_VERISON.$DESIRED_GO_MINOR_VERISON"


### PR DESCRIPTION
## Summary:
In Khan/webapp#29424, I make it so the protobuf compiler is installed
at need, when running `make protos` in webapp.  There is no need to
install it globally anymore!

Issue: none

## Test plan:
None