### PR TITLE
Install python3.11-dev on linux developer machines

### DIFF
--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -152,7 +152,7 @@ EOF
 
     # Python3 is needed to run the python services (e.g. ai-guide-core).
     # We are on python3.11 now
-    sudo apt-get install -y python3.11 python3.11-venv
+    sudo apt-get install -y python3.11 python3.11-venv python3.11-dev
 
     # Install curl for setup script usage
     sudo apt-get install -y curl


### PR DESCRIPTION
## Summary:
As with https://github.com/Khan/aws-config/pull/132, we need to install
python3.11-dev so that services/ai-guide-core can build
google-cloud-profiler as added here:

https://github.com/Khan/webapp/pull/29190

I don't think this needs to be done for mac as `brew install python3.11`
appears to already install the header files we need.

Issue: https://khanacademy.slack.com/archives/C096UP7D0/p1738862081336129?thread_ts=1738861368.096579&cid=C096UP7D0

## Test plan:
1. Run `make` in khan-dotfiles.
2. Attempt to install google-cloud-profiler in webapp/services/ai-guide-core:
   `../../genfiles/services/ai-guide-core/venv/bin/pip install google-cloud-profiler`