### PR TITLE
Remove git-workflow things, as those are now moving into OLC

### DIFF
--- a/.gitconfig.khan
+++ b/.gitconfig.khan
@@ -20,7 +20,7 @@
 
   # Branch management for dealing with github-style deploys.
   # e.g. deploy-branch, review-branch, find-reviewers
-  # Note that these reference scripts from Khan/git-workflow
+  # Note that these reference scripts from Khan/our-lovely-cli
   # Those scripts should be installed and part of the default path.
   rgrep = !git recursive-grep
   findreviewers = !git find-reviewers ; old-style had no dash in name

--- a/.gitconfig.khan
+++ b/.gitconfig.khan
@@ -22,7 +22,6 @@
   # e.g. deploy-branch, review-branch, find-reviewers
   # Note that these reference scripts from Khan/our-lovely-cli
   # Those scripts should be installed and part of the default path.
-  rgrep = !git recursive-grep
   findreviewers = !git find-reviewers ; old-style had no dash in name
 
   # Abbreviations for KA specific tools

--- a/.profile.khan
+++ b/.profile.khan
@@ -13,7 +13,6 @@ fi
 # Add devtools bins to PATH
 # TODO(mroth): rewrite these paths at install time based on user preference
 KA_DEVROOT="$HOME/khan/devtools"
-export PATH="$KA_DEVROOT/git-workflow/bin:$PATH"
 export PATH="$KA_DEVROOT/our-lovely-cli/bin:$PATH"
 export PATH="$KA_DEVROOT/ka-clone/bin:$PATH"
 export PATH="$KA_DEVROOT/khan-linter/bin:$PATH"

--- a/setup.sh
+++ b/setup.sh
@@ -211,7 +211,6 @@ clone_devtools() {
     echo "Installing devtools"
     clone_devtool git@github.com:Khan/ka-clone    # already cloned, so will --repair the first time
     clone_devtool git@github.com:Khan/khan-linter
-    clone_devtool git@github.com:Khan/git-workflow
     clone_devtool git@github.com:Khan/our-lovely-cli
 }
 


### PR DESCRIPTION
## Summary:
For the MFE project, we will want to make sure things like `git deploy-branch` support `main` as the default branch in repos where `main` _is_ the default branch.

To make that happen, we first need to bring the git-workflow repo into OLC (while preserving the git history), so that we can update the scripts and have them show up on folks' computers automatically. (This was a decision made in [this ADR](https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/3283484677/ADR+769+Rethink+our+Standard+Local+Git+Setup+Between+Dotfiles+and+OLC+-+Part+2#Git-Workflow-Repo).)

Rough plan:
1. Bring git-workflow into OLC while preserving the git history ([PR here](https://github.com/Khan/our-lovely-cli/pull/970))
2. Remove any no-longer-needed-files from OLC ([PR here](https://github.com/Khan/our-lovely-cli/pull/971))
3. Combine the README.md in OLC ([PR here](https://github.com/Khan/our-lovely-cli/pull/972))
4. Update git-workflow repo with deprecation messages ([PR here](https://github.com/Khan/git-workflow/pull/6))
5. Update khan-dotfiles repo to no long install git-workflow 👈 **YOU ARE HERE**
6. Update the scripts to support `main`, etc. ([PR here](https://github.com/Khan/our-lovely-cli/pull/973))

Issue: FEI-6455

## Test plan:
If a user is setting up a new computer, then they should get the git scripts as part of OLC now