### PR TITLE
Do not add khanacademy.dev to /etc/hosts.

### DIFF
--- a/bin/edit-system-config.sh
+++ b/bin/edit-system-config.sh
@@ -42,9 +42,3 @@ ZSHSHARE="/usr/local/share/zsh"
 if [[ -d "${ZSHSHARE}" ]]; then
     chmod -R 755 "${ZSHSHARE}"
 fi
-
-if ! grep -q khanacademy.dev /etc/hosts; then
-    echo "Adding khanacademy.dev to /etc/hosts"
-    echo "127.0.0.1 storage.khanacademy.dev khanacademy.dev www.khanacademy.dev" | \
-        sudo tee -a /etc/hosts
-fi


### PR DESCRIPTION
## Summary:
Instead, we created a real DNS entry for it, in godaddy:
   https://mxtoolbox.com/SuperTool.aspx?action=a%3akhanacademy.dev&run=toolpage

Depending on DNS is better than depending on this, because as we add
new hostnames (e.g. classroom.khanacademy.dev), they will Just Work
rather than needing everyone to re-run khan-dotfiles.

Issue: https://khanacademy.slack.com/archives/C02NMB1R5/p1746653331624719

## Test plan:
Fingers crossed

Subscribers: @dbraley, @reidmit