### PR TITLE
Add my version of git mm as an alias, but with helpful link so as not to stomp on people

### DIFF
--- a/.gitconfig.khan
+++ b/.gitconfig.khan
@@ -39,6 +39,20 @@
   pown = "!git pull origin $(git branch-name)"
   pupl = pup --force-with-lease
 
+  # Here are some new aliases that we wanted to share, but that could be the same as people's custom
+  # aliases, so this link takes you to a doc on how to fix that while preserving this file under
+  # source control.
+  notyours = "!sh -c \"echo 'khan command \\033[4;33mgit ${GIT_ALIAS_NAME:-unknown}\\033[0m: \\033[34mhttps://khanacademy.org/r/gitfaq#id-6d95\\033[0m'\""
+
+	# Needed for merge queues, updates local deploy branch with changes on origin/<master|main>
+	mm = "!f() { \
+	      GIT_ALIAS_NAME=mm git notyours && \
+	      git co $1 && \
+	      (git pown || echo '⚠️  git pull failed, continuing...') && \
+	      git fetch origin "$(git symbolic-ref refs/remotes/origin/HEAD | awk -F'/' '{print $NF}')" && \
+	      git merge --no-edit origin/"$(git symbolic-ref refs/remotes/origin/HEAD | awk -F'/' '{print $NF}')" \
+	      && git pup; }; f"
+
   # Commands for manipulating deploy tags.
   # which-deploy: in which deploy did this commit first go out?
   # prev-deploy and next-deploy: what deploys came before and after this one?


### PR DESCRIPTION
## Summary:
We really need the `git mm` alias for the merge queue flow. I started w Jeff Yates's version, and made it more robust. It just syncs your local deploy branch with changes from `origin/<master|main>`, but it doesn't error in the case where your local deploy branch could have been deleted (which happens with merge queues). And it knows the diff between `master` and `main`.

It seems like this may be a somewhat common alias that people already have, and I wanted to make sure that if we override their version that they have a way to override it back. This pull request adds a sub-command alias with a link that redirects to a question on an FAQ that answers how to do that. We can reuse this for other aliases we want to add that could step on toes. 

I thought about this problem a lot over the last few months and I think this is a fairly elegant, lowest-touch solution.
Issue: FEI-6635
Issue: FEI-6635

## Test plan:
- Run `git mm` in a repo that has `.gitconfig.khan` included, see that it runs mine
- Follow link
- Try instructions for putting yours back (if you have one), see that _that_ works