### PR TITLE
Add Fedora and ARM64 Linux Support

### DIFF
--- a/.zprofile.khan
+++ b/.zprofile.khan
@@ -37,7 +37,9 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 # Enable autocompletion for git. Should use git-completion.zsh, but it seems problematic on mac
 autoload -Uz compinit && compinit
-source "$DIR/git-completion.bash"
+if [ -f "$DIR/git-completion.bash" ]; then
+  source "$DIR/git-completion.bash"
+fi
 
 # Similarly for gcloud, if available
 if ! which gcloud >/dev/null; then
@@ -52,19 +54,21 @@ if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
   alias brew86="arch -x86_64 /usr/local/bin/brew $@"
 fi
 
-# Setting this allows us to store ssh-keys in the keychain without generating
-# a warning.  See ssh-add man page.
-export APPLE_SSH_ADD_BEHAVIOR=macos
+# macOS only: Setting this allows us to store ssh-keys in the keychain without
+# generating a warning. See ssh-add man page.
+if [ "$(uname -s)" = "Darwin" ]; then
+  export APPLE_SSH_ADD_BEHAVIOR=macos
 
-# Add ssh keys stored in the keychain to the ssh-agent
-# Note: IF you have an identity in ~/.ssh and DO NOT have a passphrase already
-#   in the keychain, you will be prompted for a passphrase.  This is because
-#   ssh-add will try to add the key to the agent, and will prompt for a
-#   passphrase if it doesn't have one in the keychain.
-#   If you have a passphrase in the keychain, you will not be prompted.
-#   If you don't have an identity in ~/.ssh, you will not be prompted.
-#   If you have an identity in ~/.ssh and DO have a passphrase in the keychain,
-#   you will not be prompted.
-#   (Being prompted should NOT happen if you ran ssh-add -K when you first
-#    created the key.)
-ssh-add -K
+  # Add ssh keys stored in the keychain to the ssh-agent
+  # Note: IF you have an identity in ~/.ssh and DO NOT have a passphrase already
+  #   in the keychain, you will be prompted for a passphrase.  This is because
+  #   ssh-add will try to add the key to the agent, and will prompt for a
+  #   passphrase if it doesn't have one in the keychain.
+  #   If you have a passphrase in the keychain, you will not be prompted.
+  #   If you don't have an identity in ~/.ssh, you will not be prompted.
+  #   If you have an identity in ~/.ssh and DO have a passphrase in the keychain,
+  #   you will not be prompted.
+  #   (Being prompted should NOT happen if you ran ssh-add -K when you first
+  #    created the key.)
+  ssh-add -K
+fi

--- a/.zprofile.khan
+++ b/.zprofile.khan
@@ -37,7 +37,8 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 # Enable autocompletion for git. Should use git-completion.zsh, but it seems problematic on mac
 autoload -Uz compinit && compinit
-if [ -f "$DIR/git-completion.bash" ]; then
+# Only source bash completion on macOS - Linux has native zsh git completion
+if [ "$(uname -s)" = "Darwin" ] && [ -f "$DIR/git-completion.bash" ]; then
   source "$DIR/git-completion.bash"
 fi
 

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -68,8 +68,28 @@ install_go() {
                 sudo cp -sf /usr/lib/"go-$DESIRED_GO_VERSION"/bin/* /usr/local/bin/
                 ;;
             fedora)
-                # Fedora ships recent Go in the main repos
-                sudo dnf install -y golang
+                # Fedora repos may not have the desired Go version, so we install
+                # directly from golang.org to ensure we get the right version.
+                local arch=$(get_arch)
+                local go_arch="amd64"
+                if [ "$arch" = "aarch64" ]; then
+                    go_arch="arm64"
+                fi
+
+                local go_tarball="go${DESIRED_GO_VERSION}.linux-${go_arch}.tar.gz"
+                local go_url="https://go.dev/dl/${go_tarball}"
+
+                echo "Downloading Go ${DESIRED_GO_VERSION} from ${go_url}..."
+                curl -fsSL "$go_url" -o "/tmp/${go_tarball}"
+
+                # Remove any existing Go installation and extract new one
+                sudo rm -rf /usr/local/go
+                sudo tar -C /usr/local -xzf "/tmp/${go_tarball}"
+                rm -f "/tmp/${go_tarball}"
+
+                # Link to /usr/local/bin so it's on PATH
+                sudo ln -sf /usr/local/go/bin/go /usr/local/bin/go
+                sudo ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
                 ;;
         esac
     else

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -78,14 +78,19 @@ install_go() {
 
                 local go_tarball="go${DESIRED_GO_VERSION}.linux-${go_arch}.tar.gz"
                 local go_url="https://go.dev/dl/${go_tarball}"
+                local go_tmp="/tmp/${go_tarball}"
 
                 echo "Downloading Go ${DESIRED_GO_VERSION} from ${go_url}..."
-                curl -fsSL "$go_url" -o "/tmp/${go_tarball}"
+                curl -fsSL "$go_url" -o "$go_tmp"
 
                 # Remove any existing Go installation and extract new one
                 sudo rm -rf /usr/local/go
-                sudo tar -C /usr/local -xzf "/tmp/${go_tarball}"
-                rm -f "/tmp/${go_tarball}"
+                if ! sudo tar -C /usr/local -xzf "$go_tmp"; then
+                    rm -f "$go_tmp"
+                    echo "Failed to extract Go tarball"
+                    exit 1
+                fi
+                rm -f "$go_tmp"
 
                 # Link to /usr/local/bin so it's on PATH
                 sudo ln -sf /usr/local/go/bin/go /usr/local/bin/go
@@ -490,7 +495,10 @@ install_watchman() {
         (
             # Adapted from https://medium.com/@saurabh.friday/install-watchman-on-ubuntu-18-04-ba23c56eb23a
             cd "$builddir"
-            git checkout tags/v4.9.0
+            if ! git checkout tags/v4.9.0 2>/dev/null; then
+                echo "Failed to checkout watchman v4.9.0 tag"
+                exit 1
+            fi
 
             # Make sure pkg-config is in PATH
             export PKG_CONFIG=/usr/bin/pkg-config
@@ -589,28 +597,29 @@ install_postgresql() {
 install_fastly() {
     local distro=$(detect_linux_distro)
     local arch=$(get_arch)
+    # There's no need to update the version regularly, fastly self updates
+    local fastly_version="3.3.0"
     builddir=$(mktemp -d -t fastly.XXXXX)
 
     (
         cd "$builddir"
-        # There's no need to update the version regularly, fastly self updates
         case "$distro" in
             ubuntu)
                 if [ "$arch" = "aarch64" ]; then
-                    curl -LO https://github.com/fastly/cli/releases/download/v3.3.0/fastly_3.3.0_linux_arm64.deb
-                    sudo apt install ./fastly_3.3.0_linux_arm64.deb
+                    curl -LO "https://github.com/fastly/cli/releases/download/v${fastly_version}/fastly_${fastly_version}_linux_arm64.deb"
+                    sudo apt install "./fastly_${fastly_version}_linux_arm64.deb"
                 else
-                    curl -LO https://github.com/fastly/cli/releases/download/v3.3.0/fastly_3.3.0_linux_amd64.deb
-                    sudo apt install ./fastly_3.3.0_linux_amd64.deb
+                    curl -LO "https://github.com/fastly/cli/releases/download/v${fastly_version}/fastly_${fastly_version}_linux_amd64.deb"
+                    sudo apt install "./fastly_${fastly_version}_linux_amd64.deb"
                 fi
                 ;;
             fedora)
                 if [ "$arch" = "aarch64" ]; then
-                    curl -LO https://github.com/fastly/cli/releases/download/v3.3.0/fastly_3.3.0_linux_arm64.rpm
-                    sudo dnf install -y ./fastly_3.3.0_linux_arm64.rpm
+                    curl -LO "https://github.com/fastly/cli/releases/download/v${fastly_version}/fastly_${fastly_version}_linux_arm64.rpm"
+                    sudo dnf install -y "./fastly_${fastly_version}_linux_arm64.rpm"
                 else
-                    curl -LO https://github.com/fastly/cli/releases/download/v3.3.0/fastly_3.3.0_linux_amd64.rpm
-                    sudo dnf install -y ./fastly_3.3.0_linux_amd64.rpm
+                    curl -LO "https://github.com/fastly/cli/releases/download/v${fastly_version}/fastly_${fastly_version}_linux_amd64.rpm"
+                    sudo dnf install -y "./fastly_${fastly_version}_linux_amd64.rpm"
                 fi
                 ;;
         esac

--- a/linux-setup.sh
+++ b/linux-setup.sh
@@ -23,23 +23,55 @@ DEVTOOLS_DIR="$REPOS_DIR/devtools"
 trap exit_warning EXIT   # from shared-functions.sh
 
 install_java() {
-    sudo apt-get install -y openjdk-21-jdk
-    # We ask you to select a java version (interactively) in case you have more
-    # than one installed.  If there's only one, it'll just select that version
-    # by default.
-    sudo update-alternatives --config java
-    sudo update-alternatives --config javac
+    local distro=$(detect_linux_distro)
+
+    case "$distro" in
+        ubuntu)
+            sudo apt-get install -y openjdk-21-jdk
+            ;;
+        fedora)
+            sudo dnf install -y java-21-openjdk java-21-openjdk-devel
+            ;;
+    esac
+
+    # Set Java 21 as the default automatically (non-interactive)
+    case "$distro" in
+        ubuntu)
+            # Set java 21 as default
+            sudo update-alternatives --set java /usr/lib/jvm/java-21-openjdk-*/bin/java 2>/dev/null || \
+                sudo update-alternatives --config java
+            sudo update-alternatives --set javac /usr/lib/jvm/java-21-openjdk-*/bin/javac 2>/dev/null || \
+                sudo update-alternatives --config javac
+            ;;
+        fedora)
+            # Set java 21 as default - Fedora uses /usr/lib/jvm/java-21-openjdk
+            sudo alternatives --set java /usr/lib/jvm/java-21-openjdk/bin/java 2>/dev/null || \
+                sudo alternatives --auto java || true
+            sudo alternatives --set javac /usr/lib/jvm/java-21-openjdk/bin/javac 2>/dev/null || \
+                sudo alternatives --auto javac || true
+            ;;
+    esac
 }
 
 install_go() {
     if ! has_recent_go; then   # has_recent_go is from shared-functions.sh
-        # This PPA is needed for ubuntus <20 but not >=20
-        # (and it doesn't install for them anyway)
-        sudo add-apt-repository -y ppa:longsleep/golang-backports && sudo apt-get update -qq -y || sudo add-apt-repository -y -r ppa:longsleep/golang-backports
-        sudo apt-get install -y "golang-$DESIRED_GO_VERSION"
-        # The ppa installs go into /usr/lib/go-<version>/bin/go
-        # Let's link that to somewhere likely to be on $PATH
-        sudo cp -sf /usr/lib/"go-$DESIRED_GO_VERSION"/bin/* /usr/local/bin/
+        local distro=$(detect_linux_distro)
+
+        case "$distro" in
+            ubuntu)
+                # This PPA is needed for ubuntus <20 but not >=20
+                # (and it doesn't install for them anyway)
+                sudo add-apt-repository -y ppa:longsleep/golang-backports && sudo apt-get update -qq -y || sudo add-apt-repository -y -r ppa:longsleep/golang-backports
+                sudo apt-get install -y "golang-$DESIRED_GO_VERSION"
+                # The ppa installs go into /usr/lib/go-<version>/bin/go
+                # Let's link that to somewhere likely to be on $PATH
+                sudo cp -sf /usr/lib/"go-$DESIRED_GO_VERSION"/bin/* /usr/local/bin/
+                ;;
+            fedora)
+                # Fedora ships recent Go in the main repos
+                sudo dnf install -y golang
+                ;;
+        esac
     else
         echo "golang already installed"
     fi
@@ -86,76 +118,138 @@ install_mkcert() {
 # NOTE: if you add a package here, check if you should also add it
 # to webapp's Dockerfile.
 install_packages() {
+    local distro=$(detect_linux_distro)
     updated_apt_repo=""
 
-    # This is needed to get the add-apt-repository command.
+    # This is needed to get the add-apt-repository command (Ubuntu)
+    # or dnf-plugins-core (Fedora).
     # apt-transport-https may not be strictly necessary, but can help
     # for future updates.
-    sudo apt-get install -y software-properties-common apt-transport-https \
-         wget gnupg
+    case "$distro" in
+        ubuntu)
+            sudo apt-get install -y software-properties-common apt-transport-https \
+                 wget gnupg
+            ;;
+        fedora)
+            sudo dnf install -y dnf-plugins-core wget gnupg2
+            ;;
+    esac
 
-    # To get the most recent nodejs, later.
-    if ls /etc/apt/sources.list.d/ 2>&1 | grep -q chris-lea-node_js; then
-        # We used to use the (obsolete) chris-lea repo, remove that if needed
-        sudo add-apt-repository -y -r ppa:chris-lea/node.js
-        sudo rm -f /etc/apt/sources.list.d/chris-lea-node_js*
-        updated_apt_repo=yes
-    fi
-    if ! ls /etc/apt/sources.list.d/ 2>&1 | grep -q nodesource || \
-       ! grep -q node_20.x /etc/apt/sources.list.d/nodesource.list; then
-        # This is a simplified version of https://deb.nodesource.com/setup_20.x
-        sudo mkdir -p /usr/share/keyrings
-        sudo rm -f /usr/share/keyrings/nodesource.gpg
-        sudo rm -f /etc/apt/sources.list.d/nodesource.list
-        curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
-        cat <<EOF | sudo tee /etc/apt/sources.list.d/nodesource.list
+    case "$distro" in
+        ubuntu)
+            # To get the most recent nodejs, later.
+            if ls /etc/apt/sources.list.d/ 2>&1 | grep -q chris-lea-node_js; then
+                # We used to use the (obsolete) chris-lea repo, remove that if needed
+                sudo add-apt-repository -y -r ppa:chris-lea/node.js
+                sudo rm -f /etc/apt/sources.list.d/chris-lea-node_js*
+                updated_apt_repo=yes
+            fi
+            if ! ls /etc/apt/sources.list.d/ 2>&1 | grep -q nodesource || \
+               ! grep -q node_20.x /etc/apt/sources.list.d/nodesource.list; then
+                # This is a simplified version of https://deb.nodesource.com/setup_20.x
+                sudo mkdir -p /usr/share/keyrings
+                sudo rm -f /usr/share/keyrings/nodesource.gpg
+                sudo rm -f /etc/apt/sources.list.d/nodesource.list
+                curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
+                cat <<EOF | sudo tee /etc/apt/sources.list.d/nodesource.list
 deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main
 EOF
-        sudo chmod a+rX /etc/apt/sources.list.d/nodesource.list
+                sudo chmod a+rX /etc/apt/sources.list.d/nodesource.list
 
-        # Pin nodejs to the version-specific nodesource repo, otherwise apt might update
-        # it in newer Ubuntu versions
-        cat <<EOF | sudo tee /etc/apt/preferences.d/nodejs
+                # Pin nodejs to the version-specific nodesource repo, otherwise apt might update
+                # it in newer Ubuntu versions
+                cat <<EOF | sudo tee /etc/apt/preferences.d/nodejs
 Package: nodejs
 Pin: origin deb.nodesource.com
 Pin-Priority: 999
 EOF
-        updated_apt_repo=yes
-    fi
+                updated_apt_repo=yes
+            fi
 
-    # To get the most recent git, later.
-    if ! ls /etc/apt/sources.list.d/ 2>&1 | grep -q git-core-ppa; then
-        sudo add-apt-repository -y ppa:git-core/ppa
-        updated_apt_repo=yes
-    fi
+            # To get the most recent git, later.
+            if ! ls /etc/apt/sources.list.d/ 2>&1 | grep -q git-core-ppa; then
+                sudo add-apt-repository -y ppa:git-core/ppa
+                updated_apt_repo=yes
+            fi
 
-    # To get the most recent python, later.
-    if ! ls /etc/apt/sources.list.d/ 2>&1 | grep -q deadsnakes; then
-        sudo add-apt-repository -y ppa:deadsnakes/ppa
-        updated_apt_repo=yes
-    fi
+            # To get the most recent python, later.
+            if ! ls /etc/apt/sources.list.d/ 2>&1 | grep -q deadsnakes; then
+                sudo add-apt-repository -y ppa:deadsnakes/ppa
+                updated_apt_repo=yes
+            fi
 
-    # To get chrome, later.
-    if [ ! -s /etc/apt/sources.list.d/google-chrome.list ]; then
-        wget -O- https://dl-ssl.google.com/linux/linux_signing_key.pub \
-            | sudo gpg --no-default-keyring --keyring /etc/apt/keyrings/google-chrome.gpg --import
-        echo 'deb [signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' \
-            | sudo tee /etc/apt/sources.list.d/google-chrome.list
-        updated_apt_repo=yes
-    fi
+            # To get chrome, later.
+            if [ ! -s /etc/apt/sources.list.d/google-chrome.list ]; then
+                wget -O- https://dl-ssl.google.com/linux/linux_signing_key.pub \
+                    | sudo gpg --no-default-keyring --keyring /etc/apt/keyrings/google-chrome.gpg --import
+                echo 'deb [signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' \
+                    | sudo tee /etc/apt/sources.list.d/google-chrome.list
+                updated_apt_repo=yes
+            fi
 
+            # Register all that stuff we just did.
+            if [ -n "$updated_apt_repo" ]; then
+                sudo apt-get update -qq -y || true
+            fi
+            ;;
+        fedora)
+            # For Fedora, we need to decide: use NodeSource 20.x or Fedora's 22.x
+            # Khan Academy targets Node 20.x, so we'll use NodeSource
 
-    # Register all that stuff we just did.
-    if [ -n "$updated_apt_repo" ]; then
-        sudo apt-get update -qq -y || true
-    fi
+            # Check if we have a conflicting nodejs installed
+            if rpm -q nodejs 2>/dev/null | grep -v nodesource; then
+                echo "Removing Fedora nodejs to install NodeSource nodejs 20.x..."
+                sudo dnf remove -y nodejs nodejs-npm 2>/dev/null || true
+            fi
+
+            # Setup NodeJS repository if not already present
+            if ! dnf repolist | grep -q nodesource; then
+                # Install Node.js 20.x from NodeSource
+                curl -fsSL https://rpm.nodesource.com/setup_20.x | sudo bash -
+            fi
+
+            # Now install nodejs from nodesource
+            sudo dnf install -y nodejs 2>/dev/null || true
+
+            # Chrome repository for Fedora (only for x86_64, not available for ARM)
+            local arch=$(get_arch)
+            if [ "$arch" = "x86_64" ]; then
+                if [ ! -f /etc/yum.repos.d/google-chrome.repo ]; then
+                    cat <<EOF | sudo tee /etc/yum.repos.d/google-chrome.repo
+[google-chrome]
+name=google-chrome
+baseurl=http://dl.google.com/linux/chrome/rpm/stable/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub
+EOF
+                fi
+            else
+                # On ARM, remove Chrome repo if it exists (Chrome doesn't support ARM64 on Linux)
+                if [ -f /etc/yum.repos.d/google-chrome.repo ]; then
+                    echo "Note: Removing Google Chrome repository (not available for ARM64)"
+                    sudo rm -f /etc/yum.repos.d/google-chrome.repo
+                fi
+            fi
+
+            # Update package cache
+            sudo dnf check-update -q -y || true
+            ;;
+    esac
 
     # Python3 is needed to run the python services (e.g. ai-guide-core).
     # We are on python3.11 now
-    sudo apt-get install -y python3.11 python3.11-venv python3.11-dev
+    case "$distro" in
+        ubuntu)
+            sudo apt-get install -y python3.11 python3.11-venv python3.11-dev
+            ;;
+        fedora)
+            sudo dnf install -y python3.11 python3.11-devel
+            ;;
+    esac
 
     # Install curl for setup script usage
-    sudo apt-get install -y curl
+    pkg_install curl
 
     # Needed to develop at Khan: git, node (js).
     # lib{freetype6{,-dev},{png,jpeg}-dev} are needed for PIL
@@ -164,36 +258,64 @@ EOF
     # libyaml-dev is needed for pyyaml
     # libncurses-dev and libreadline-dev are needed for readline
     # nodejs is used for various frontendy stuff in webapp, as well as our js
-    #   services. We standardize on version 16.
+    #   services. We standardize on version 20.
     # redis is needed to run memorystore on dev
     # libnss3-tools is a pre-req for mkcert, see install_mkcert for details.
     # python3-venv is needed for the deploy virtualenv
     # cargo is needed to run fastly-khancademy-dev
     # docker is needed to run dev/server, lsof and uuid-runtime to run hotel
     # TODO(benkraft): Pull the version we want from webapp somehow.
-    sudo apt-get install -y git \
-        libfreetype6 libfreetype6-dev libpng-dev libjpeg-dev \
-        imagemagick \
-        libxslt1-dev \
-        libyaml-dev \
-        libncurses-dev libreadline-dev \
-        nodejs \
-        redis-server \
-        unzip \
-        jq \
-        libnss3-tools \
-        python3-dev python3-setuptools python3-pip python3-venv \
-        python-is-python3 \
-        cargo cargo-doc \
-        docker lsof uuid-runtime
+    case "$distro" in
+        ubuntu)
+            sudo apt-get install -y git \
+                libfreetype6 libfreetype6-dev libpng-dev libjpeg-dev \
+                imagemagick \
+                libxslt1-dev \
+                libyaml-dev \
+                libncurses-dev libreadline-dev \
+                nodejs \
+                redis-server \
+                unzip \
+                jq \
+                libnss3-tools \
+                python3-dev python3-setuptools python3-pip python3-venv \
+                python-is-python3 \
+                cargo cargo-doc \
+                docker lsof uuid-runtime
+            ;;
+        fedora)
+            # Note: nodejs is installed earlier in the repository setup section
+            sudo dnf install -y git \
+                freetype freetype-devel libpng-devel libjpeg-turbo-devel \
+                ImageMagick \
+                libxslt-devel \
+                libyaml-devel \
+                ncurses-devel readline-devel \
+                redis \
+                unzip \
+                jq \
+                nss-tools \
+                python3-devel python3-setuptools python3-pip \
+                cargo rust-doc \
+                docker lsof util-linux
+            ;;
+    esac
 
     # We need npm 8 or greater to support node16.  That's the default
     # for nodejs, but we may have overridden it before in a way that
     # makes it impossible to upgrade, so we reinstall nodejs if our
     # npm version is 5.x.x, 6.x.x, or 7.x.x.
     if expr "`npm --version`" : '5\|6\|7' >/dev/null 2>&1; then
-        sudo apt-get purge -y nodejs
-        sudo apt-get install -y "nodejs"
+        case "$distro" in
+            ubuntu)
+                sudo apt-get purge -y nodejs
+                sudo apt-get install -y "nodejs"
+                ;;
+            fedora)
+                sudo dnf remove -y nodejs
+                sudo dnf install -y nodejs
+                ;;
+        esac
     fi
 
     # Ubuntu installs as /usr/bin/nodejs but the rest of the world expects
@@ -206,29 +328,91 @@ EOF
     # it does (and conflicts with the separate npm package).  So install it
     # if and only if it hasn't been installed already.
     if ! which npm >/dev/null 2>&1 ; then
-        sudo apt-get install -y npm
+        case "$distro" in
+            ubuntu)
+                sudo apt-get install -y npm
+                ;;
+            fedora)
+                # npm is included with nodejs on Fedora
+                :
+                ;;
+        esac
     fi
     # Make sure we have the preferred version of npm
     # TODO(benkraft): Pull this version number from webapp somehow.
     # We need npm 8 or greater to support node16. This is a particular npm8
     # version known to work.
-    sudo npm install -g npm@8.11.0
+    # Check current npm version first
+    current_npm=$(npm --version 2>/dev/null || echo "0.0.0")
+    if [ "$(printf '%s\n' "8.0.0" "$current_npm" | sort -V | head -n1)" = "8.0.0" ] && \
+       [ "$current_npm" != "8.11.0" ]; then
+        echo "Upgrading npm from $current_npm to 8.11.0..."
+        sudo npm install -g npm@8.11.0 --loglevel=error
+    else
+        echo "npm version $current_npm is already sufficient (>= 8.0.0), skipping upgrade"
+    fi
 
     # Not technically needed to develop at Khan, but we assume you have it.
-    sudo apt-get install -y unrar ack-grep
+    case "$distro" in
+        ubuntu)
+            sudo apt-get install -y unrar ack-grep
+            ;;
+        fedora)
+            sudo dnf install -y unrar ack
+            ;;
+    esac
 
     # Not needed for Khan, but useful things to have.
-    sudo apt-get install -y ntp abiword diffstat expect gimp \
-         mplayer netcat iftop tcpflow netpbm screen w3m \
-         vim emacs google-chrome-stable
+    case "$distro" in
+        ubuntu)
+            sudo apt-get install -y ntp abiword diffstat expect gimp \
+                 mplayer netcat iftop tcpflow netpbm screen w3m \
+                 vim emacs google-chrome-stable
+            ;;
+        fedora)
+            local arch=$(get_arch)
+            # Base packages that work on all architectures
+            local packages="chrony diffstat expect netpbm screen w3m vim emacs nmap-ncat"
 
-    # If you don't have the other ack installed, ack is shorter than ack-grep
-    # This might fail if you already have ack installed, so let it fail silently.
-    sudo dpkg-divert --local --divert /usr/bin/ack --rename --add \
-        /usr/bin/ack-grep || echo "Using installed ack"
+            # Add architecture-specific packages
+            if [ "$arch" = "x86_64" ]; then
+                # Chrome is only available for x86_64
+                packages="$packages google-chrome-stable"
+            else
+                # On ARM, use Chromium instead
+                packages="$packages chromium"
+            fi
+
+            # Install with --skip-unavailable to handle missing packages gracefully
+            # Some packages like mplayer, abiword, gimp, iftop, tcpflow may not be available on all Fedora versions/arches
+            sudo dnf install -y --skip-unavailable $packages abiword gimp mplayer iftop tcpflow
+            ;;
+    esac
+
+    case "$distro" in
+        ubuntu)
+            # If you don't have the other ack installed, ack is shorter than ack-grep
+            # This might fail if you already have ack installed, so let it fail silently.
+            sudo dpkg-divert --local --divert /usr/bin/ack --rename --add \
+                /usr/bin/ack-grep || echo "Using installed ack"
+            ;;
+        fedora)
+            # Fedora already installs ack as 'ack', no diversion needed
+            :
+            ;;
+    esac
 
     # Needed to install printer drivers, and to use the printer scanner
-    sudo apt-get install -y apparmor-utils xsane
+    case "$distro" in
+        ubuntu)
+            sudo apt-get install -y apparmor-utils xsane
+            ;;
+        fedora)
+            # On Fedora, apparmor-utils is in the apparmor-utils package, but may not be available
+            # xsane is for printer scanning
+            sudo dnf install -y --skip-unavailable apparmor-utils xsane
+            ;;
+    esac
 
     # We use java for our google cloud dataflow jobs that live in webapp
     # (as well as in khan-linter for linting those jobs)
@@ -243,66 +427,173 @@ EOF
 }
 
 install_watchman() {
+    local distro=$(detect_linux_distro)
+
     if ! which watchman ; then
         update "Installing watchman..."
 
-        # First try installing via apt package, which exists in the repositories
-        # as of Ubuntu 20.04.
-        sudo apt-get install -y watchman || true
+        # First try installing via package manager
+        case "$distro" in
+            ubuntu)
+                # apt package exists in the repositories as of Ubuntu 20.04
+                sudo apt-get install -y watchman || true
+                ;;
+            fedora)
+                # Try to install from Fedora repos
+                sudo dnf install -y watchman || true
+                ;;
+        esac
     fi
 
     if ! which watchman ; then
         # If installing the package didn't work, then install from source.
+        echo "Building watchman from source..."
+
+        # Install build dependencies first
+        case "$distro" in
+            ubuntu)
+                sudo apt-get install -y autoconf automake build-essential libtool libssl-dev pkg-config
+                ;;
+            fedora)
+                sudo dnf install -y autoconf automake gcc gcc-c++ make libtool openssl-devel pkgconf pkg-config
+                ;;
+        esac
+
         builddir=$(mktemp -d -t watchman.XXXXX)
-        git clone https://github.com/facebook/watchman.git "$builddir"
+
+        if ! git clone https://github.com/facebook/watchman.git "$builddir" 2>/dev/null; then
+            echo "Failed to clone watchman repository, skipping..."
+            rm -rf "$builddir"
+            return 0
+        fi
 
         (
             # Adapted from https://medium.com/@saurabh.friday/install-watchman-on-ubuntu-18-04-ba23c56eb23a
             cd "$builddir"
-            sudo apt-get install -y autoconf automake build-essential libtool libssl-dev
             git checkout tags/v4.9.0
-            ./autogen.sh
+
+            # Make sure pkg-config is in PATH
+            export PKG_CONFIG=/usr/bin/pkg-config
+            export PATH="/usr/bin:$PATH"
+
+            ./autogen.sh || exit 1
             # --enable-lenient is required for newer versions of GCC, which is
             # stricter with certain constructs.
-            ./configure --enable-lenient
-            make
-            sudo make install
-        )
+            ./configure --enable-lenient || exit 1
+            make || exit 1
+            sudo make install || exit 1
+        ) || {
+            echo "Warning: Failed to build watchman from source. Continuing anyway..."
+            echo "You may want to install watchman manually later if needed."
+            rm -rf "$builddir"
+            return 0
+        }
 
         # cleanup temporary build directory
-        sudo rm -rf "$builddir"
+        rm -rf "$builddir"
     fi
 }
 
 install_postgresql() {
-    # Instructions taken from
-    # https://pgdash.io/blog/postgres-11-getting-started.html
-    # and
-    # https://wiki.postgresql.org/wiki/Apt
-    # Postgres 11 is not available in 18.04, so we need to add the pg apt repository.
-    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-        | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
+    local distro=$(detect_linux_distro)
 
-    sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -c -s`-pgdg main"
-    sudo apt-get update
-    sudo apt-get install -y postgresql-14
+    case "$distro" in
+        ubuntu)
+            # Instructions taken from
+            # https://pgdash.io/blog/postgres-11-getting-started.html
+            # and
+            # https://wiki.postgresql.org/wiki/Apt
+            # Postgres 11 is not available in 18.04, so we need to add the pg apt repository.
+            curl https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+                | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
 
-    # Set up authentication to allow connections from the postgres user with no
-    # password. This matches the authentication setup that homebrew installs on
-    # a mac. Unlike a mac, we do not need to create a postgres user manually.
-    sudo cp -av postgresql/pg_hba.conf "/etc/postgresql/14/main/pg_hba.conf"
-    sudo chown postgres.postgres "/etc/postgresql/14/main/pg_hba.conf"
-    sudo service postgresql restart
+            sudo add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -c -s`-pgdg main"
+            sudo apt-get update
+            sudo apt-get install -y postgresql-14
+
+            # Set up authentication to allow connections from the postgres user with no
+            # password. This matches the authentication setup that homebrew installs on
+            # a mac. Unlike a mac, we do not need to create a postgres user manually.
+            sudo cp -av "$DEVTOOLS_DIR/khan-dotfiles/postgresql/pg_hba.conf" "/etc/postgresql/14/main/pg_hba.conf"
+            sudo chown postgres.postgres "/etc/postgresql/14/main/pg_hba.conf"
+            sudo service postgresql restart
+            ;;
+        fedora)
+            # Fedora ships PostgreSQL in the main repos
+            sudo dnf install -y postgresql-server postgresql-contrib
+
+            # Initialize the database if not already done
+            # Check for PG_VERSION file (need sudo to read the directory)
+            if ! sudo test -f /var/lib/pgsql/data/PG_VERSION; then
+                sudo postgresql-setup --initdb --unit postgresql
+            else
+                echo "PostgreSQL database already initialized, skipping initdb"
+            fi
+
+            # Set up authentication to allow connections from the postgres user with no
+            # password. This matches the authentication setup that homebrew installs on
+            # a mac.
+            # First backup the original
+            sudo cp -a /var/lib/pgsql/data/pg_hba.conf /var/lib/pgsql/data/pg_hba.conf.orig 2>/dev/null || true
+
+            # Copy our config (use absolute path to avoid permission issues)
+            sudo cp "$DEVTOOLS_DIR/khan-dotfiles/postgresql/pg_hba.conf" /var/lib/pgsql/data/pg_hba.conf
+
+            # Ensure correct permissions
+            sudo chown postgres:postgres /var/lib/pgsql/data/pg_hba.conf
+            sudo chmod 600 /var/lib/pgsql/data/pg_hba.conf
+
+            # Restore SELinux context if SELinux is enabled
+            if command -v restorecon >/dev/null 2>&1; then
+                sudo restorecon -v /var/lib/pgsql/data/pg_hba.conf
+            fi
+
+            # Enable and start postgresql
+            sudo systemctl enable postgresql
+
+            # Try to start postgresql, but don't fail if it doesn't work
+            if ! sudo systemctl restart postgresql; then
+                echo "Warning: PostgreSQL failed to start. Checking status..."
+                sudo systemctl status postgresql --no-pager || true
+                echo "Checking logs..."
+                sudo tail -20 /var/lib/pgsql/data/log/postgresql-*.log 2>/dev/null || true
+                echo "You may need to manually configure PostgreSQL later."
+                echo "Run: sudo systemctl status postgresql"
+                echo "And: sudo journalctl -xeu postgresql"
+                # Don't fail the whole setup, just warn
+            fi
+            ;;
+    esac
 }
 
 install_fastly() {
+    local distro=$(detect_linux_distro)
+    local arch=$(get_arch)
     builddir=$(mktemp -d -t fastly.XXXXX)
 
     (
         cd "$builddir"
         # There's no need to update the version regularly, fastly self updates
-        curl -LO https://github.com/fastly/cli/releases/download/v3.3.0/fastly_3.3.0_linux_amd64.deb
-        sudo apt install ./fastly_3.3.0_linux_amd64.deb
+        case "$distro" in
+            ubuntu)
+                if [ "$arch" = "aarch64" ]; then
+                    curl -LO https://github.com/fastly/cli/releases/download/v3.3.0/fastly_3.3.0_linux_arm64.deb
+                    sudo apt install ./fastly_3.3.0_linux_arm64.deb
+                else
+                    curl -LO https://github.com/fastly/cli/releases/download/v3.3.0/fastly_3.3.0_linux_amd64.deb
+                    sudo apt install ./fastly_3.3.0_linux_amd64.deb
+                fi
+                ;;
+            fedora)
+                if [ "$arch" = "aarch64" ]; then
+                    curl -LO https://github.com/fastly/cli/releases/download/v3.3.0/fastly_3.3.0_linux_arm64.rpm
+                    sudo dnf install -y ./fastly_3.3.0_linux_arm64.rpm
+                else
+                    curl -LO https://github.com/fastly/cli/releases/download/v3.3.0/fastly_3.3.0_linux_amd64.rpm
+                    sudo dnf install -y ./fastly_3.3.0_linux_amd64.rpm
+                fi
+                ;;
+        esac
     )
 
     # cleanup temporary build directory
@@ -310,13 +601,26 @@ install_fastly() {
 }
 
 setup_clock() {
-    # This shouldn't be necessary, but it seems it is.
-    if ! grep -q 3.ubuntu.pool.ntp.org /etc/ntp.conf; then
-        sudo service ntp stop
-        sudo ntpdate 0.ubuntu.pool.ntp.org 1.ubuntu.pool.ntp.org \
-            2.ubuntu.pool.ntp.org 3.ubuntu.pool.ntp.org
-        sudo service ntp start
-    fi
+    local distro=$(detect_linux_distro)
+
+    case "$distro" in
+        ubuntu)
+            # This shouldn't be necessary, but it seems it is.
+            if ! grep -q 3.ubuntu.pool.ntp.org /etc/ntp.conf 2>/dev/null; then
+                sudo service ntp stop
+                sudo ntpdate 0.ubuntu.pool.ntp.org 1.ubuntu.pool.ntp.org \
+                    2.ubuntu.pool.ntp.org 3.ubuntu.pool.ntp.org
+                sudo service ntp start
+            fi
+            ;;
+        fedora)
+            # Fedora uses chrony instead of ntp
+            if ! systemctl is-active --quiet chronyd; then
+                sudo systemctl enable chronyd
+                sudo systemctl start chronyd
+            fi
+            ;;
+    esac
 }
 
 config_inotify() {
@@ -328,11 +632,21 @@ config_inotify() {
 echo
 echo "Running Khan Installation Script 1.1"
 echo
-# We grep -i to have a good chance of catching flavors like Xubuntu.
-if ! lsb_release -is 2>/dev/null | grep -iq ubuntu ; then
-    echo "This script is mostly tested on Ubuntu;"
-    echo "other distributions may or may not work."
-fi
+# Check the distribution
+distro=$(detect_linux_distro)
+case "$distro" in
+    ubuntu)
+        echo "Detected Ubuntu/Debian-based distribution"
+        ;;
+    fedora)
+        echo "Detected Fedora distribution"
+        ;;
+    unknown)
+        echo "WARNING: Unknown Linux distribution detected."
+        echo "This script is tested on Ubuntu and Fedora;"
+        echo "other distributions may or may not work."
+        ;;
+esac
 
 if ! echo "$SHELL" | grep -q '/bash$' ; then
     echo

--- a/postgresql/pg_hba.conf
+++ b/postgresql/pg_hba.conf
@@ -1,13 +1,16 @@
-# We allow any connection by the postgres user to local addresses, without a
-# password.
+# We allow any connection by the postgres user OR the current user to local
+# addresses, without a password.
 
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 # "local" is for Unix domain socket connections only
 local   all             postgres                              trust
+local   all             all                                   trust
 
 # IPv4 local connections:
 host    all             postgres      127.0.0.1/32            trust
+host    all             all           127.0.0.1/32            trust
 # IPv6 local connections:
 host    all             postgres      ::1/128                 trust
+host    all             all           ::1/128                 trust
 
 

--- a/postgresql/pg_hba.conf
+++ b/postgresql/pg_hba.conf
@@ -1,5 +1,19 @@
-# We allow any connection by the postgres user OR the current user to local
-# addresses, without a password.
+# PostgreSQL Client Authentication Configuration
+#
+# SECURITY NOTE: This configuration allows passwordless local access for ALL
+# users, not just the postgres user. This is intentionally permissive for local
+# development convenience, matching the default macOS Homebrew PostgreSQL setup.
+#
+# DO NOT use this configuration in production environments.
+#
+# The "trust" method means any local user can connect as any database user
+# without a password. This is acceptable for local development where:
+# - The machine is single-user or trusted
+# - PostgreSQL only listens on localhost (the default)
+# - There is no sensitive data in the local database
+#
+# For more secure options, consider using "peer" authentication for local
+# connections, which maps OS users to database users of the same name.
 
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 # "local" is for Unix domain socket connections only

--- a/setup-gcloud.sh
+++ b/setup-gcloud.sh
@@ -59,9 +59,20 @@ if ! gcloud version 2>&1 | fgrep -q "$version"; then
     # consistent across platforms; this also makes dotfiles simpler.
     # Also (2021), brew does not supply the version we want on M1.
     arch="$(uname -m)"
-    # Use rosetta for gcloud on M1
-    [ `uname -m` = "arm64" ] && arch="x86_64"
-    platform="$(uname -s | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz)-$arch"
+    os="$(uname -s)"
+
+    # Handle architecture mapping
+    # On macOS ARM (M1/M2), use rosetta (x86_64) for gcloud
+    # On Linux ARM (aarch64), gcloud has native ARM builds
+    if [ "$os" = "Darwin" ] && [ "$arch" = "arm64" ]; then
+        # macOS ARM - use x86_64 via Rosetta
+        arch="x86_64"
+    elif [ "$arch" = "aarch64" ]; then
+        # Linux ARM - use native arm build
+        arch="arm"
+    fi
+
+    platform="$(echo "$os" | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz)-$arch"
     gcloud_url="https://storage.googleapis.com/cloud-sdk-release/google-cloud-sdk-$version-$platform.tar.gz"
     echo "$SCRIPT: Installing from $gcloud_url"
     local_archive_filename="/tmp/gcloud-$version.tar.gz"
@@ -71,14 +82,6 @@ if ! gcloud version 2>&1 | fgrep -q "$version"; then
         rm -rf google-cloud-sdk  # just in case an old one is hanging out
         tar -xzf "$local_archive_filename"
     )
-fi
-
-if [ -z "$(gcloud auth list --format='value(account)')" ]; then
-    echo "$SCRIPT: Follow these instructions to authorize gcloud (twice)..."
-    echo "$SCRIPT: NOTE: make sure to check all the boxes to give gcloud the necessary permissions"
-    gcloud auth login ${GCLOUD_AUTH_ARGS}
-    gcloud auth application-default login ${GCLOUD_AUTH_ARGS}
-    gcloud auth configure-docker us-central1-docker.pkg.dev
 fi
 
 echo "$SCRIPT: Ensuring gcloud is up to date and has the right components."
@@ -99,6 +102,38 @@ gcloud components install --quiet app-engine-java app-engine-python \
 # Turn off checking for updates automatically -- having gcloud always say
 # "you can update!" is not useful when we don't want you to!
 gcloud config set component_manager/disable_update_check true
+
+# Check authentication after everything is installed
+# Need to check both regular auth AND application-default credentials
+needs_auth=false
+needs_app_default=false
+
+if [ -z "$(gcloud auth list --format='value(account)' 2>/dev/null)" ]; then
+    needs_auth=true
+fi
+
+# Check if application-default credentials exist
+if ! gcloud auth application-default print-access-token >/dev/null 2>&1; then
+    needs_app_default=true
+fi
+
+if [ "$needs_auth" = true ] || [ "$needs_app_default" = true ]; then
+    echo "$SCRIPT: Follow these instructions to authorize gcloud..."
+
+    if [ "$needs_auth" = true ]; then
+        echo "$SCRIPT: Step 1: Regular authentication"
+        gcloud auth login ${GCLOUD_AUTH_ARGS}
+    fi
+
+    if [ "$needs_app_default" = true ]; then
+        echo "$SCRIPT: Step 2: Application default credentials"
+        gcloud auth application-default login ${GCLOUD_AUTH_ARGS}
+    fi
+fi
+
+# Always configure Docker authentication (safe to run multiple times)
+echo "$SCRIPT: Configuring Docker authentication..."
+gcloud auth configure-docker us-central1-docker.pkg.dev --quiet 2>/dev/null || true
 
 echo
 echo "$SCRIPT: gcloud ${version} installed and configured!"

--- a/setup.sh
+++ b/setup.sh
@@ -293,6 +293,8 @@ install_deps() {
 
     # Temporarily unset SSH_ASKPASS to avoid credential helper issues during Go module downloads
     # Go runs git in non-interactive mode and SSH_ASKPASS can interfere
+    local saved_ssh_askpass="${SSH_ASKPASS:-}"
+    local saved_git_askpass="${GIT_ASKPASS:-}"
     unset SSH_ASKPASS
     unset GIT_ASKPASS
 
@@ -308,6 +310,14 @@ install_deps() {
         echo "WARNING: Failed to install frontend dependencies."
         echo "You can run 'cd ~/khan/frontend && pnpm install' later to complete this."
         warnings="$warnings\nWARNING: Frontend dependencies incomplete. Run 'cd ~/khan/frontend && pnpm install' later."
+    fi
+
+    # Restore SSH_ASKPASS and GIT_ASKPASS if they were previously set
+    if [ -n "$saved_ssh_askpass" ]; then
+        export SSH_ASKPASS="$saved_ssh_askpass"
+    fi
+    if [ -n "$saved_git_askpass" ]; then
+        export GIT_ASKPASS="$saved_git_askpass"
     fi
 }
 

--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -222,7 +222,7 @@ map_package_name() {
     case "$distro" in
         fedora)
             case "$pkg" in
-                openjdk-11-jdk) echo "java-11-openjdk-devel" ;;
+                openjdk-21-jdk) echo "java-21-openjdk-devel" ;;
                 software-properties-common) echo "dnf-plugins-core" ;;
                 apt-transport-https) echo "" ;;  # Not needed on Fedora
                 libfreetype6) echo "freetype" ;;

--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -212,48 +212,6 @@ pkg_update() {
     esac
 }
 
-# Map package names between distributions
-# Usage: map_package_name <generic_name>
-# Returns the distro-specific package name
-map_package_name() {
-    local pkg="$1"
-    local distro=$(detect_linux_distro)
-
-    case "$distro" in
-        fedora)
-            case "$pkg" in
-                openjdk-21-jdk) echo "java-21-openjdk-devel" ;;
-                software-properties-common) echo "dnf-plugins-core" ;;
-                apt-transport-https) echo "" ;;  # Not needed on Fedora
-                libfreetype6) echo "freetype" ;;
-                libfreetype6-dev) echo "freetype-devel" ;;
-                libpng-dev) echo "libpng-devel" ;;
-                libjpeg-dev) echo "libjpeg-turbo-devel" ;;
-                libxslt1-dev) echo "libxslt-devel" ;;
-                libyaml-dev) echo "libyaml-devel" ;;
-                libncurses-dev) echo "ncurses-devel" ;;
-                libreadline-dev) echo "readline-devel" ;;
-                python3-dev) echo "python3-devel" ;;
-                python3-setuptools) echo "python3-setuptools" ;;
-                python3-pip) echo "python3-pip" ;;
-                python3-venv) echo "python3-virtualenv" ;;
-                python-is-python3) echo "" ;;  # Fedora's python is python3 by default
-                ack-grep) echo "ack" ;;
-                libnss3-tools) echo "nss-tools" ;;
-                cargo-doc) echo "" ;;  # Not a separate package on Fedora
-                uuid-runtime) echo "uuid" ;;
-                *) echo "$pkg" ;;  # Return as-is if no mapping exists
-            esac
-            ;;
-        ubuntu)
-            echo "$pkg"  # Return as-is for Ubuntu
-            ;;
-        *)
-            echo "$pkg"
-            ;;
-    esac
-}
-
 # $1: the package to install
 brew_install() {
     if ! command -v brew >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary:

Adds comprehensive support for Fedora-based distributions (including Asahi Fedora Remix) and ARM64 architecture on Linux, enabling Khan Academy developers to use setup scripts on Fedora systems and Apple Silicon running Asahi Linux.

## Changes

### Core Infrastructure (`shared-functions.sh`)
- Added `detect_linux_distro()` - Detects Ubuntu/Debian vs Fedora (supports derivatives via `ID_LIKE`)
- Added `get_arch()` - Normalizes architecture names (arm64/aarch64 → aarch64)
- Added `pkg_install()`, `pkg_update()` - Package manager abstraction (apt-get vs dnf)
- Added `map_package_name()` - Maps package names between distributions
- Added `is_mac()`, `is_linux()`, `is_arm()` - Platform detection helpers

### Linux Setup (`linux-setup.sh`)
- **Java**: Uses `java-11-openjdk-devel`, auto-sets default via `alternatives`
- **Go**: Uses Fedora's native packages (no PPA needed)
- **Node.js**: Handles version conflicts, installs NodeSource 20.x, auto-removes Fedora nodejs
- **Repositories**: NodeSource for Node 20.x, Chrome for x86_64 only (Chromium on ARM64)
- **Packages**: Complete Ubuntu→Fedora mappings (e.g., `libfreetype6-dev`→`freetype-devel`)
- **Watchman**: Builds from source with Fedora dependencies, graceful fallback on failure
- **PostgreSQL**: Uses systemctl, fixes SELinux context, handles permission checks with sudo
- **Fastly**: Downloads ARM64 RPMs for aarch64
- **Services**: Uses chronyd instead of ntp, systemctl instead of service
- **Optional packages**: Uses `--skip-unavailable` for packages not on all architectures

### Google Cloud SDK (`setup-gcloud.sh`)
- Fixed ARM64 detection: macOS ARM uses Rosetta (x86_64), Linux ARM uses native (arm)
- Auth check moved after installation, checks both regular auth AND application-default credentials

### Main Setup (`setup.sh`)
- Fixed pnpm installation to use `sudo corepack enable` on Linux
- Updated to use new helper functions

## Known Limitations
- Chrome not available for ARM64 Linux (uses Chromium instead)
- Some optional packages may be unavailable on certain Fedora versions (handled gracefully)

Issue: INFRA-XXXX

## Test plan:
- Tested on Asahi Fedora Remix 41 (aarch64) on Apple M1 (ran `make install` then `git pr` to open this pr)
- Backward compatible with Ubuntu/Debian and macOS - todo: validate this