### PR TITLE
Fix python link

### DIFF
--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -268,7 +268,7 @@ install_python_tools() {
         brew install python@3.11
     fi
     # The python3 formula does not install `python` as a symlink, so we do.
-    if ! [ -e "$(brew --prefix)/bin/python"]; then
+    if ! [ -e "$(brew --prefix)/bin/python" ]; then
         ln -snf "$(brew --prefix)/opt/python@3.11/libexec/bin/python" "$(brew --prefix)/bin/python"
     fi
 

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -268,8 +268,8 @@ install_python_tools() {
         brew install python@3.11
     fi
     # The python3 formula does not install `python` as a symlink, so we do.
-    if ! [ -e /usr/local/bin/python ]; then
-        ln -snf python3 /usr/local/bin/python
+    if ! [ -e "$(brew --prefix)/bin/python"]; then
+        ln -snf "$(brew --prefix)/opt/python@3.11/libexec/bin/python" "$(brew --prefix)/bin/python"
     fi
 
     # We use various python versions (e.g. internal-service)


### PR DESCRIPTION
## Summary

Fix python symlink by using `brew --prefix` in path.

We had a recent batch of Google Fellows run through `khan-dotfiles` on their new Macs, and they all ran into a problem [here](https://github.com/khan/khan-dotfiles/blob/d87d6f706a0d1111662d34903a672274606097a6/mac-setup-normal.sh#L271):
`ln: /usr/local/bin/python: No such file or directory`

It looks like `/usr/local/bin` is not created by default on modern Macs, which was causing the error. Additionally, `brew install` no longer installs to `/usr/local/bin`, so there would be no `python3` sibling to link to.

I found an [old thread](https://khanacademy.slack.com/archives/C02NMB1R5/p1712088499883109?thread_ts=1710546934.835669&cid=C02NMB1R5) that recommended this fix for the `python3` issue:
`ln -snf /opt/homebrew/bin/python3 /usr/local/bin/python`

This is my proposed solution. We could also just symlink to the sibling `python3` in `$(brew --prefix)/bin`, which would be the installed `python@3.11`, rather than being explicit with the `$(brew --prefix)/opt/python@3.11/libexec/bin/python` path. Or, if we only need `python3` in the path now, we could remove this step entirely.

## Test plan

- Run the changed script segment in isolation to verify symlink is created correctly
