### PR TITLE
Check for ed25519 SSH key

### DIFF
--- a/shared-functions.sh
+++ b/shared-functions.sh
@@ -190,7 +190,7 @@ maybe_generate_ssh_keys() {
   # Create a public key if need be.
   info "Checking for ssh keys"
   mkdir -p ~/.ssh
-  if [ -s ~/.ssh/id_rsa ] || [ -s ~/.ssh/id_ecdsa ]; then
+  if [ -s ~/.ssh/id_rsa ] || [ -s ~/.ssh/id_ecdsa ] || [ -s ~/.ssh/id_ed25519 ]; then
     # TODO(ebrown): Verify these key(s) have passphrases on them
     success "Found existing ssh keys"
   else


### PR DESCRIPTION
## Summary:
I set up a new machine today and noticed it didn't detect my SSH key.

Issue: none

## Test plan:
I re-ran `make` with this change applied.