### PR TITLE
Add --frontend-only flag setup.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
-install:
-	./git_sync.sh
-	$(MAKE) wipe-generated-profile-file
-	$(MAKE) os-install
-	$(MAKE) common-install
+define REBOOT_MESSAGE
 	@echo "***  YOU MUST REBOOT **IF** this was   ***"
 	@echo "***  the first time you've setup       ***"
 	@echo "***  khan-dotfiles (i.e. if you are    ***"
 	@echo "***  onboarding)                       ***"
 	@echo "***  (Reboot is required for browser   ***"
 	@echo "***  to pickup CA for khanacademy.dev) ***"
+endef
+
+install:
+	./git_sync.sh
+	$(MAKE) wipe-generated-profile-file
+	$(MAKE) os-install
+	$(MAKE) common-install
+	$(REBOOT_MESSAGE)
 	@echo ""
 	@echo "To finish your setup, head back to the"
 	@echo "setup docs:"
@@ -30,14 +34,9 @@ common-install:
 
 frontend-only:
 	./git_sync.sh
-	rm -f ~/.profile-generated.khan && touch ~/.profile-generated.khan
+	$(MAKE) wipe-generated-profile-file
 	if [ `uname -s` = Darwin ]; then \
 		./mac-setup.sh --frontend-only; \
 	fi
 	./setup.sh --frontend-only
-	@echo "***  YOU MUST REBOOT **IF** this was   ***"
-	@echo "***  the first time you've setup       ***"
-	@echo "***  khan-dotfiles (i.e. if you are    ***"
-	@echo "***  onboarding)                       ***"
-	@echo "***  (Reboot is required for browser   ***"
-	@echo "***  to pickup CA for khanacademy.dev) ***"
+	$(REBOOT_MESSAGE)

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,17 @@ os-install:
 
 common-install:
 	./setup.sh
+
+frontend-only:
+	./git_sync.sh
+	rm -f ~/.profile-generated.khan && touch ~/.profile-generated.khan
+	if [ `uname -s` = Darwin ]; then \
+		./mac-setup.sh --frontend-only; \
+	fi
+	./setup.sh --frontend-only
+	@echo "***  YOU MUST REBOOT **IF** this was   ***"
+	@echo "***  the first time you've setup       ***"
+	@echo "***  khan-dotfiles (i.e. if you are    ***"
+	@echo "***  onboarding)                       ***"
+	@echo "***  (Reboot is required for browser   ***"
+	@echo "***  to pickup CA for khanacademy.dev) ***"

--- a/mac-setup-elevated.sh
+++ b/mac-setup-elevated.sh
@@ -11,12 +11,14 @@ SCRIPT=$(basename $0)
 usage() {
     cat << EOF
 usage: $SCRIPT [options]
-  --root <dir> Use specified directory as root (instead of HOME).
+  --root <dir>     Use specified directory as root (instead of HOME).
+  --frontend-only  Only install tools needed for frontend development.
 EOF
 }
 
 # Install in $HOME by default, but can set an alternate destination via $1.
 ROOT="${ROOT:-$HOME}"
+FRONTEND_ONLY=false
 
 # Process command line arguments
 while [[ "$1" != "" ]]; do
@@ -24,6 +26,9 @@ while [[ "$1" != "" ]]; do
         -r | --root)
             shift
             ROOT=$1
+            ;;
+        --frontend-only)
+            FRONTEND_ONLY=true
             ;;
         -h | --help)
             usage
@@ -72,6 +77,8 @@ fi
 # It used to be we needed to install xcode-tools, now homebrew does this for us
 #"$DEVTOOLS_DIR"/khan-dotfiles/bin/install-mac-gcc.sh
 
-# We use java for our google cloud dataflow jobs that live in webapp
-# (as well as in khan-linter for linting those jobs)
-install_mac_java
+if [ "$FRONTEND_ONLY" != "true" ]; then
+    # We use java for our google cloud dataflow jobs that live in webapp
+    # (as well as in khan-linter for linting those jobs)
+    install_mac_java
+fi

--- a/mac-setup-normal.sh
+++ b/mac-setup-normal.sh
@@ -15,7 +15,26 @@ tty_bold=`tput bold`
 tty_normal=`tput sgr0`
 
 # The directory to which all repositories will be cloned.
-ROOT=${1-$HOME}
+ROOT="${HOME}"
+FRONTEND_ONLY=false
+
+# Process command line arguments
+while [[ "$1" != "" ]]; do
+    case $1 in
+        -r | --root)
+            shift
+            ROOT=$1
+            ;;
+        --frontend-only)
+            FRONTEND_ONLY=true
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+    esac
+    shift
+done
+
 REPOS_DIR="$ROOT/khan"
 
 # Derived path location constants
@@ -328,11 +347,14 @@ uninstall_node_mac
 # The actual installation of these tools is done in `setup_mise` in setup.sh.
 install_mise_mac
 
-"$DEVTOOLS_DIR"/khan-dotfiles/bin/mac-setup-postgres.py
+if [ "$FRONTEND_ONLY" != "true" ]; then
+    "$DEVTOOLS_DIR"/khan-dotfiles/bin/mac-setup-postgres.py
 
-install_redis
-install_image_utils
-install_helpful_tools
+    install_redis
+    install_image_utils
+    install_helpful_tools
+fi
+
 install_watchman
 install_python_tools
 install_fastly

--- a/mac-setup.sh
+++ b/mac-setup.sh
@@ -8,14 +8,16 @@ SCRIPT=$(basename $0)
 usage() {
     cat << EOF
 usage: $SCRIPT [options]
-  --root <dir> Use specified directory as root (instead of HOME).
-  --all        Install all user apps.
-  --none       Install no user apps.
+  --root <dir>     Use specified directory as root (instead of HOME).
+  --all            Install all user apps.
+  --none           Install no user apps.
+  --frontend-only  Only install tools needed for frontend development.
 EOF
 }
 
 # Install in $HOME by default, but can set an alternate destination via $1.
 ROOT="${ROOT:-$HOME}"
+FRONTEND_ONLY_FLAG=""
 
 # Process command line arguments
 while [[ "$1" != "" ]]; do
@@ -29,6 +31,9 @@ while [[ "$1" != "" ]]; do
             ;;
         -n | --none)
             APPS="-n"
+            ;;
+        --frontend-only)
+            FRONTEND_ONLY_FLAG="--frontend-only"
             ;;
         -h | --help)
             usage
@@ -73,11 +78,8 @@ fi
 
 read -p "Press enter to continue..."
 
-# TODO(ericbrown): Pass command line arguments below
-# Note that ensure parsing arguments (above) doesn't hide anything
-
 # Run setup that requires sudo access
-"$DEVTOOLS_DIR"/khan-dotfiles/mac-setup-elevated.sh "$APPS"
+"$DEVTOOLS_DIR"/khan-dotfiles/mac-setup-elevated.sh $APPS $FRONTEND_ONLY_FLAG
 
 # Run setup that does NOT require sudo access
-"$DEVTOOLS_DIR"/khan-dotfiles/mac-setup-normal.sh
+"$DEVTOOLS_DIR"/khan-dotfiles/mac-setup-normal.sh $FRONTEND_ONLY_FLAG

--- a/setup.sh
+++ b/setup.sh
@@ -55,6 +55,10 @@ DIR=$(dirname "$0")
 IS_MAC=$(which sw_vers || echo "")
 IS_MAC_ARM=$(test "$(uname -m)" = "arm64" && echo arm64 || echo "")
 
+if [ "$FRONTEND_ONLY" = "true" ] && [ -z "$IS_MAC" ]; then
+    echo "WARNING: --frontend-only is intended for macOS only and may not work correctly on this system."
+fi
+
 # On a clean install of Mac OS X, /opt/homebrew/bin is not in the PATH.
 # Thus, stuff installed with the arm64 version of homebrew is not visible.
 # (This was not the case on intel macs where /usr/local/bin is in the path
@@ -246,7 +250,9 @@ clone_repos() {
     clone_kaclone
     clone_devtools
     clone_webapp
-    clone_mobile
+    if [ "$FRONTEND_ONLY" != "true" ]; then
+        clone_mobile
+    fi
     clone_frontend
     kaclone_repair_self
 }
@@ -350,9 +356,9 @@ clone_repos
 install_and_setup_gcloud     # pre-req: setup_python
 install_deps                 # pre-reqs: clone_repos, install_and_setup_gcloud
 install_our_lovely_cli_deps  # pre-req: clone_repos, install_deps
+install_hooks                # pre-req: clone_repos
 
 if [ "$FRONTEND_ONLY" != "true" ]; then
-    install_hooks                # pre-req: clone_repos
     download_db_dump             # pre-req: install_deps
     create_pg_databases          # pre-req: install_deps
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -10,8 +10,27 @@
 # Bail on any errors
 set -e
 
-# Install in $HOME by default, but can set an alternate destination via $1.
-ROOT=${1-$HOME}
+# Install in $HOME by default, but can set an alternate destination via --root.
+ROOT="${HOME}"
+FRONTEND_ONLY=false
+
+# Process command line arguments
+while [[ "$1" != "" ]]; do
+    case $1 in
+        -r | --root)
+            shift
+            ROOT=$1
+            ;;
+        --frontend-only)
+            FRONTEND_ONLY=true
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+    esac
+    shift
+done
+
 mkdir -p "$ROOT"
 
 # the directory all repositories will be cloned to
@@ -331,9 +350,12 @@ clone_repos
 install_and_setup_gcloud     # pre-req: setup_python
 install_deps                 # pre-reqs: clone_repos, install_and_setup_gcloud
 install_our_lovely_cli_deps  # pre-req: clone_repos, install_deps
-install_hooks                # pre-req: clone_repos
-download_db_dump             # pre-req: install_deps
-create_pg_databases          # pre-req: install_deps
+
+if [ "$FRONTEND_ONLY" != "true" ]; then
+    install_hooks                # pre-req: clone_repos
+    download_db_dump             # pre-req: install_deps
+    create_pg_databases          # pre-req: install_deps
+fi
 
 echo
 echo "---------------------------------------------------------------------"

--- a/setup.sh
+++ b/setup.sh
@@ -198,7 +198,11 @@ clone_webapp() {
     # By this point, we must have git and ka-clone working, so a failure likely
     # means the user doesn't have access to webapp (it's the only private repo
     # we clone here) -- we give a more useful error than just "not found".
-    kaclone_repo git@github.com:Khan/webapp "$REPOS_DIR/" -p --email="$gitmail" --pre-push-lint || add_fatal_error \
+    local depth_flag=""
+    if [ "$FRONTEND_ONLY" = "true" ]; then
+        depth_flag="--depth=1"
+    fi
+    kaclone_repo git@github.com:Khan/webapp "$REPOS_DIR/" -p --email="$gitmail" --pre-push-lint $depth_flag || add_fatal_error \
         "Unable to clone Khan/webapp -- perhaps you don't have access? " \
         "If you can't view https://github.com/Khan/webapp, ask #it in " \
         "Slack to be added."


### PR DESCRIPTION
**Description by @jonahgoldsaito, see below for the original comment**

## Summary:

The organization is looking for a way for designers and eventually PMs and other product oriented non-engineers to spin up `prototype/[feature-name]` branches of the `frontend` repo. These are never meant to be deployed, but instead used to:

1. Experiment on the actual source of truth
2. Demonstrate ideas internally as quickly as possible
3. Validate ideas in real user-tests by letting users see their own data via new experiences that they otherwise would have to imagine from a concocted scenario.
4. Handoff as a starting point for engineers to work from if concept are validated and approved. SKILLs will be used to guide agents towards using correct tokens, components, a11y, i10n, and general patterns, so the head start will be considerable over pointing a engineer towards a Figma file, as was traditionally done.

### Why local dev is necessary (for now)

While frontend prototyping can be done via web-based Claude, removing the need for a local dev environment altogether, the iteration loop takes nearly 5 minutes to see the results of any agentic query because it requires pushing a ZND. This doesn't fit into the type of rapid iteration that's needed with a local dev environment's hot-reloading.

Given that, we need a way to simplify and streamline local dev setup for non-engineers. The `--frontend-only` flag is A **FIRST STEP** in this larger effort! 

### Notes:

- This flag should not be run by engineers or anyone planning on deploying frontend / webapp
- The flag only has any effect on MacOS machines because it's assumed that all designers are using MacOS.
- This flag will be limited to designers only so the blast radius is small. When we scale to more roles, we can devise cleaner solutions

Sal has green-lit this effort with urgency and is excited to roll out this type of frontend prototyping for larger cohorts by BTS.

@jeresig has also been in the loop

---

## Original comment (@kevinb-khan)

The purpose of this flag is to make it so that non-engineers who want to vibe code prototypes within webapp don't have to install as much stuff when setting things up. The flag only has any effect on MacOS machines because it's assumed that all designers are using MacOS.

Issue: FEI-7369

## Test plan:

- Clone the repo and then run 'setup.sh --frontend-only' on a machine that hasn't run the setup script before.