### PR TITLE
[Security Update] Upgrade to Node 24.18

### DIFF
--- a/mise_config.toml
+++ b/mise_config.toml
@@ -2,4 +2,4 @@
 trusted_config_paths = ['~/khan/']
 
 [tools]
-node = { version = "24.13", postinstall = "corepack enable" }
+node = { version = "24.18", postinstall = "corepack enable" }


### PR DESCRIPTION
## Summary:

Updates our global mise configuration to use Node v24.18. Our current version has two known CVEs and so we want to upgrade to ensure we're not exposed.

This PR will land _after_ I've updated the Github workflows in the following repositories:
  * Khan/frontend
  * Khan/webapp
  * Khan/wonder-blocks
  * Khan/wonder-stuff
  * Khan/perseus
  * Khan/cedar-events

Issue: INFRA-11108

## Test plan:

How does one test the world?  Well, I've got this PR in place on my local machine and I'm building PRs for known repos that may be affected (frontend, webapp, wonder-blocks, wonder-stuff, perseus, agent-settings, cedar-events). As I do that, I'll be naturally testing the Node v24.18 compatibility because that'll be the version I'm doing all the work with. 

Also, our Github Actions and Docker containers require separate work that is unaffected by this Mise config so I'll be creating PRs to adjust those also.